### PR TITLE
Fixing problems and adding more features 

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -75,16 +75,14 @@ jobs:
         run: |
           cd custom_components/solar_of_things
           python3 -m py_compile \
-            __init__.py api.py config_flow.py const.py \
-            sensor.py number.py select.py switch.py
+            __init__.py api.py config_flow.py const.py diagnostics.py \
+            helpers.py sensor.py number.py select.py switch.py
+          python3 -m py_compile ../../tools/dump_solar_api.py
           echo "Python syntax OK"
 
-      - name: Run unit tests (if present)
+      - name: Run unit tests
         run: |
-          pip install --quiet pytest pytest-asyncio || true
-          if [ -d tests ]; then
-            python3 -m pytest tests/ -v --tb=short \
-              || echo "Tests completed (failures tolerated without full HA fixtures)"
-          else
-            echo "No tests directory — skipping"
-          fi
+          pip install --quiet pytest pytest-asyncio
+          # The value-resolution tests run without Home Assistant installed;
+          # the config-flow tests skip themselves when the HA harness is absent.
+          python3 -m pytest tests/ -v --tb=short

--- a/API_CAPTURE.md
+++ b/API_CAPTURE.md
@@ -1,0 +1,124 @@
+# Capturing the API data behind an "unknown" entity
+
+Almost every `unknown` entity in this integration has the same cause: the
+portal reports the value under an attribute name (or in a payload) that the
+integration is not looking at. Nothing is broken on your inverter — we just
+need the name your model actually uses.
+
+There are three ways to collect that, easiest first. **Option 1 is enough for
+most reports.**
+
+---
+
+## Option 1 — Download diagnostics from Home Assistant (recommended)
+
+1. **Settings → Devices & Services → Solar of Things**
+2. Click the **⋮** menu on the integration card → **Download diagnostics**
+3. Attach the downloaded `.json` file to a GitHub issue
+
+The file contains, per device:
+
+| Section | What it tells us |
+|---|---|
+| `time_series_keys` | attribute names the history endpoint returned |
+| `settings_keys` | keys present in the remote-config cache (often empty — that is normal) |
+| `state_field_keys` | **every attribute your inverter publishes** — this is the important one |
+| `state_fields` | the full snapshot, with each value, display label and unit |
+| `resolution` | which names the integration searched, what it found, and how it mapped them |
+
+Credentials, tokens and your account ID are stripped automatically. Device
+names and readings are not, so give the file a quick look before posting it.
+
+---
+
+## Option 2 — Enable debug logging
+
+Add to `configuration.yaml` and restart:
+
+```yaml
+logger:
+  default: warning
+  logs:
+    custom_components.solar_of_things: debug
+```
+
+On the first poll after startup the integration logs one line per device
+listing every attribute name it saw:
+
+```
+SolarOfThings device 8765…4321 attribute names — time-series: [...] |
+settings-cache: [...] | state-snapshot: [...]
+```
+
+It also logs a warning whenever a priority value cannot be mapped onto a known
+option, including the raw value and display string. Both lines are exactly what
+is needed to add a mapping.
+
+You can see the same information without the log: the two priority select
+entities expose `source`, `api_key`, `raw_value` and `raw_display` as entity
+attributes (**Developer tools → States**), and the *Charger Priority (current)*
+/ *Output Priority (current)* diagnostic sensors show the label the API
+returned verbatim.
+
+---
+
+## Option 3 — Run the dump script against your account
+
+For a full capture without Home Assistant in the way:
+
+```bash
+pip install requests pycryptodome
+python3 tools/dump_solar_api.py --user-id YOUR_ID --station-id YOUR_STATION_ID
+```
+
+It prompts for the password (never stored), logs in, and prints the attribute
+names from all three endpoints plus how each contested value resolves. The same
+data is written to `solar_of_things_dump.json`.
+
+Your station ID is the long number in the portal URL when a station is open.
+
+---
+
+## Option 4 — Capture from the portal with browser DevTools
+
+Useful when the portal shows a value that no endpoint above seems to carry —
+it proves which request the web UI itself used.
+
+1. Open <https://solar.siseli.com/#/operator/overview> and log in
+2. Press **F12** → **Network** tab → filter `Fetch/XHR`
+3. Tick **Preserve log**, then open the page that shows the value in question
+   (the device detail page for live readings, the control panel for the
+   priority settings)
+4. Find the request whose **Response** contains the value you can see on screen
+   — usually one of:
+   - `deviceState/simple/state/latest/v1` — live readings
+   - `deviceState/simple/attribute/keys/history/v1` — charts
+   - `remote/device/configs/cache/get` — remote-control panel
+5. Right-click the request → **Copy → Copy response**, and paste it into the
+   issue
+
+**Before pasting, remove these:** the `IOT-Token` request header, anything under
+`accessToken` / `refreshToken`, and your account ID. They grant full access to
+your account. Only the response *body* is needed — never the request headers.
+
+---
+
+## Adding a name once you have it
+
+Attribute names live in one place, `custom_components/solar_of_things/const.py`:
+
+- `STATE_KEY_CANDIDATES` — names in the live snapshot (selects, switches, numbers)
+- `SETTING_KEY_CANDIDATES` — names in the remote-config write cache
+- `TELEMETRY_STATE_FALLBACKS` — names for the measurement sensors, with the unit
+  family (`"power"` → normalised to W, `"energy"` → kWh, `None` → as-is)
+
+Add the new name to the relevant list; matching is case-insensitive, so
+capitalisation does not matter. For a mode reported as an unfamiliar word
+rather than a number, add it to `OUTPUT_PRIORITY_ALIASES` or
+`CHARGER_PRIORITY_ALIASES` (keys are lowercase with punctuation replaced by
+spaces). `tests/test_value_resolution.py` covers this logic and runs without a
+Home Assistant install:
+
+```bash
+python3 -m pytest tests/ -q
+```

--- a/API_CAPTURE.md
+++ b/API_CAPTURE.md
@@ -103,12 +103,35 @@ your account. Only the response *body* is needed — never the request headers.
 
 ---
 
+## Two name spaces, one control
+
+The portal reads and writes the same setting under **different names**, which is
+worth knowing before you map anything:
+
+| Direction | Endpoint | Key style | Example |
+|---|---|---|---|
+| Read (live) | `GET /apis/deviceState/simple/state/latest/v1?deviceId=…&dataSource=1` | attribute | `chargerSourcePriority` |
+| Read (cache) | `POST /apis/remote/device/configs/cache/get?deviceId=…` | setting | `settingDeviceChargerPriority` |
+| Write | `POST /apis/remote/device/config/write?deviceId=…` | setting | `settingDeviceChargerPriority` |
+
+The write body is `{"id": "<deviceId>", "key": "<settingKey>", "value": "<value>"}`.
+The field is **`id`** — a body using `deviceId` still returns `code: 0`
+("Success") while changing nothing on the inverter.
+
+The cache is populated by the portal's **Batch Read** button, which is
+`POST /apis/remote/device/configs/read` followed by polling
+`GET /apis/remote/device/configs/read/details?batchReadId=…`. Until that
+round-trips to the device, the cache returns nulls — which is why the
+integration reads the live snapshot and treats the cache as a fallback.
+
 ## Adding a name once you have it
 
 Attribute names live in one place, `custom_components/solar_of_things/const.py`:
 
-- `STATE_KEY_CANDIDATES` — names in the live snapshot (selects, switches, numbers)
-- `SETTING_KEY_CANDIDATES` — names in the remote-config write cache
+- `STATE_KEY_CANDIDATES` — names in the live snapshot (what entities read)
+- `SETTING_KEY_CANDIDATES` — names the write endpoint accepts
+- `BOOLEAN_CONTROLS` / `NUMBER_CONTROLS` — the switches and numbers to create,
+  with their on/off values and ranges
 - `TELEMETRY_STATE_FALLBACKS` — names for the measurement sensors, with the unit
   family (`"power"` → normalised to W, `"energy"` → kWh, `None` → as-is)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.5.0] - 2026-08-06
+
+### Fixed
+- **Charger Source Priority and Output Source Priority selects showed
+  `unknown`.** Both read their current value only from the remote-config cache
+  (`/apis/remote/device/configs/cache/get`), which holds just the keys that have
+  previously been *written* through the portal — on an account that has never
+  used remote control it comes back empty. They now read the live state snapshot
+  (`/apis/deviceState/simple/state/latest/v1`) first and fall back to the cache,
+  and they accept every value shape the API uses: an integer code, a numeric
+  string, an abbreviation (`"SBU"`) or a full label.
+- **Grid Feed-in Power showed `unknown`.** The history endpoint only returns the
+  attribute names it was asked for and that the model records, so models that
+  publish feed-in under another name returned nothing. Missing telemetry keys
+  are now filled from the state snapshot, with units normalised (kW → W), and
+  the derived values (`batteryPower`, `gridPower`, `loadPower`) are recomputed
+  afterwards so they benefit from the recovered readings.
+- **Number entities (charge/discharge/grid-charge limits) were unavailable.**
+  They returned the raw settings entry — a `{"key": …, "value": …}` dict —
+  instead of its value.
+- **Switches now read back from the live snapshot too**, and understand word
+  renderings (`"ON"`, `"Appliance"`) as well as integer codes.
+- **State sensors match attribute names case-insensitively**, fixing readings
+  lost to the snapshot's inconsistent capitalisation (`PV1InputVoltage` vs
+  `pv1InputCurrent`), and scale values using the unit the API reports.
+
+### Added
+- **Diagnostics support** — *Settings → Devices & Services → Solar of Things →
+  ⋮ → Download diagnostics* dumps the raw payloads with credentials, tokens and
+  the account ID redacted, including every attribute name the device publishes
+  and how each contested value resolved.
+- **`tools/dump_solar_api.py`** — standalone script that logs in and prints the
+  attribute names from all three endpoints, for capturing the same data outside
+  Home Assistant.
+- **[API_CAPTURE.md](API_CAPTURE.md)** — four ways to capture the data needed to
+  map an `unknown` entity, and how to add a new attribute name.
+- Priority selects expose `source`, `api_key`, `raw_value` and `raw_display` as
+  entity attributes, and log a warning (once per distinct value) when a value
+  cannot be mapped onto a known option.
+- Per-device attribute names are logged at debug level on the first poll.
+
+### Changed
+- All attribute names now live in candidate lists in `const.py`
+  (`STATE_KEY_CANDIDATES`, `SETTING_KEY_CANDIDATES`,
+  `TELEMETRY_STATE_FALLBACKS`), matched case-insensitively — supporting a new
+  inverter model is a one-line addition there.
+- The option ↔ integer maps are defined once in `const.py` and inverted for the
+  write path, so read-back and write cannot drift apart.
+- `tests/` runs without Home Assistant installed (36 new tests covering payload
+  shapes, unit scaling and option resolution); CI now fails on test failures
+  instead of tolerating them.
+
+---
+
 ## [2.4.2] - 2026-05-31
 
 ### Security / Quality

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.6.0] - 2026-08-07
+
+Rebuilt against captured live traffic from a PI30 / VMIII inverter on
+solar.siseli.com, which showed several of the API assumptions in earlier
+releases to be wrong.
+
+### Fixed
+- **Writes never reached the device.** The remote-config write body must be
+  `{"id": <deviceId>, "key": …, "value": …}`. Earlier releases sent `deviceId`
+  instead of `id`; the endpoint answers `code: 0` ("Success") and does nothing,
+  so every control appeared to work while changing nothing on the inverter.
+- **Writes used the wrong key names.** Reads and writes live in two different
+  name spaces: the live snapshot reports `outputSourcePriority` /
+  `chargerSourcePriority`, but the write endpoint expects
+  `settingDeviceOutputSourcePriority` / `settingDeviceChargerPriority`. Enum
+  values are sent as strings, as the portal sends them.
+- **Charger Source Priority had the wrong options.** It is the PI30 `PCP` code
+  with **four** values — 0 Utility First, 1 Solar First, 2 Solar + Utility,
+  3 Solar Only. The previous three-option CSO/SNU/OSO map matched neither what
+  the device reports nor what it accepts, so an inverter set to "Solar Only" (3)
+  could not be displayed at all.
+- **Grid Feed-in Power.** Off-grid models publish no feed-in measurement, only a
+  `solarFeedToGrid` permit flag. When feed-in is disabled the sensor now reports
+  0 W — true, and it makes the derived Grid Import figure correct — instead of
+  `unknown`.
+- **Telemetry attribute names** corrected to the ones the device actually
+  publishes: PV power is `generationPower` (kW), battery SOC is
+  `batteryCapacity`, and AC output power is reported in kW.
+- **"PV Generated" was mislabelled** — the device's own label for
+  `pvGeneratedEnergyOfDay` is "Total photovoltaic power generation". Renamed to
+  *PV Total Production*.
+
+### Removed
+- **Grid Charging (AC Input Range) switch.** The device reports
+  `inputVoltageRange` (Appliance / UPS) but the portal exposes no write key for
+  it, so the switch could not change anything. It is now the read-only
+  *Input Voltage Range* diagnostic sensor.
+- **Battery Charge Limit, Battery Discharge Limit and Grid Charge Limit.** No
+  such attributes exist on PI30/VMIII and there are no write keys for them —
+  the sliders were permanently unavailable and their writes went nowhere. The
+  current limits the device *does* report are exposed as diagnostic sensors.
+
+### Added
+- **Ten switches** for the settings the device genuinely accepts: Solar Feed to
+  Grid, Buzzer, Overload Bypass, Overload Restart, Over-temperature Restart,
+  LCD Backlight, LCD Return to Default Page, Fault Code Recording and Alarm on
+  Primary Source Interrupt, alongside Backup Mode.
+- **Three writable numbers**: battery equalization voltage, period and timeout.
+- **New sensors**: PV2 voltage/current/power, battery float and bulk voltage,
+  max charging / utility-charging / discharging current, AC and solar charging
+  status, input voltage range, model, serial number and firmware version.
+- `request_config_read()` / `fetch_config_read_details()` wrap the portal's
+  "Batch Read", which asks the inverter to report its stored configuration.
+
+### Changed
+- Control entities are now table-driven (`BOOLEAN_CONTROLS`, `NUMBER_CONTROLS`,
+  `SETTING_KEY_CANDIDATES`, `STATE_KEY_CANDIDATES` in `const.py`) — adding a
+  control is a table entry rather than a new entity class.
+- Tests cover the captured payload directly: the live snapshot resolves every
+  core measurement, and the write path is asserted byte-for-byte against what
+  the portal sends (52 tests, no Home Assistant install required).
+
+---
+
 ## [2.5.0] - 2026-08-06
 
 ### Fixed

--- a/CONTROL_FEATURES.md
+++ b/CONTROL_FEATURES.md
@@ -1,107 +1,104 @@
 # Control Features
 
-This integration exposes 8 control entities that write directly to your inverter
-via the Siseli remote-config API.
+This integration exposes 15 control entities that write directly to your
+inverter through the Siseli remote-config API.
 
-> Controls require your device and Siseli account to support the settings API.
-> Read settings are fetched every 5 minutes alongside telemetry.
+Every name and value below was captured from a live PI30 / VMIII inverter on
+solar.siseli.com. If your model differs, see [API_CAPTURE.md](API_CAPTURE.md)
+for how to find the names it uses.
 
 ---
 
-## Number Entities (Sliders)
+## How reads and writes work
 
-### Battery Charge Limit
-**Entity:** `number.{device}_battery_charge_limit`  
-**API key:** `batteryChargeLimit`  
-**Range:** 0 – 100 %  
-Sets the maximum State of Charge the inverter will charge the battery to.
+The portal uses **two different name spaces** for the same control, which is why
+earlier releases could set a value but never show it back:
 
-### Battery Discharge Limit
-**Entity:** `number.{device}_battery_discharge_limit`  
-**API key:** `batteryDischargeLimit`  
-**Range:** 0 – 100 %  
-Sets the minimum SOC at which the inverter stops discharging the battery.
-Acts as a floor for battery protection.
+| Direction | Endpoint | Key style | Example |
+|---|---|---|---|
+| Read (live) | `GET /apis/deviceState/simple/state/latest/v1` | attribute name | `chargerSourcePriority` |
+| Write | `POST /apis/remote/device/config/write` | setting name | `settingDeviceChargerPriority` |
 
-### Grid Charge Limit
-**Entity:** `number.{device}_grid_charge_limit`  
-**API key:** `gridChargeLimit`  
-**Range:** 0 – 5000 W, step 100 W  
-Maximum grid power the inverter is allowed to use for battery charging.
-Set to 0 to disable grid charging via this limit.
+The write body is `{"id": "<deviceId>", "key": "<settingKey>", "value": "<value>"}` —
+note **`id`**, not `deviceId`. Sending `deviceId` returns `code: 0` ("Success")
+and changes nothing, which is what releases before 2.6.0 did.
+
+There is also a remote-config *cache* (`/apis/remote/device/configs/cache/get`),
+but it stays empty until a batch read or write round-trips to the inverter, so
+the integration reads the live snapshot instead and uses the cache only as a
+fallback.
 
 ---
 
 ## Select Entities (Dropdowns)
 
 ### Output Source Priority
-**Entity:** `select.{device}_output_source_priority`  
-**API key:** `outputSourcePrioritySetting`
+**Entity:** `select.{device}_output_source_priority`
+**Reads:** `outputSourcePriority` · **Writes:** `settingDeviceOutputSourcePriority`
 
-| Option | API value | Description |
-|---|---|---|
-| Utility First (USO) | 0 | Grid is the primary power source; solar and battery supplement |
-| Solar First (SUB) | 1 | Solar is primary; grid fills the gap; battery charges from surplus |
-| Solar+Battery First (SBU) | 2 | Solar and battery power the load; grid only as last resort |
+| Option | API value | Device label | Description |
+|---|---|---|---|
+| Utility First (USO) | 0 | UtilitySolarBat | Grid is the primary source; solar and battery supplement |
+| Solar First (SUB) | 1 | SolarUtilityBat | Solar first, then grid, battery last |
+| Solar+Battery First (SBU) | 2 | SolarBatUtility | Solar and battery power the load; grid only as last resort |
 
 ### Charger Source Priority
-**Entity:** `select.{device}_charger_source_priority`  
-**API key:** `chargerSourcePrioritySetting`
+**Entity:** `select.{device}_charger_source_priority`
+**Reads:** `chargerSourcePriority` · **Writes:** `settingDeviceChargerPriority`
 
-| Option | API value | Description |
-|---|---|---|
-| Solar + Utility (CSO) | 0 | Both solar and grid charge the battery; utility has priority |
-| Solar First (SNU) | 1 | Solar charges the battery first; grid fills the shortfall |
-| Solar Only (OSO) | 2 | Only solar charges the battery; no grid charging |
+| Option | API value | Device label | Description |
+|---|---|---|---|
+| Utility First | 0 | — | Grid charges the battery first |
+| Solar First | 1 | for solar first | Solar charges the battery; grid fills the shortfall |
+| Solar + Utility | 2 | — | Both sources charge the battery |
+| Solar Only | 3 | Only Solar Permitted | Only solar charges the battery; no grid charging |
 
-### How the current value is read back
-
-Writes go to `POST /apis/remote/device/config/write` under the `…Setting` key
-above. Reads do **not** come from the matching config cache: that cache only
-holds keys previously written through the portal, so it is empty on accounts
-that have never used remote control — which is why these selects reported
-`unknown` before 2.5.0.
-
-The current value is read from the live snapshot
-(`GET /apis/deviceState/simple/state/latest/v1`, fields `outputSourcePriority`
-and `chargerSourcePriority`), falling back to the config cache. Both an integer
-code and a label such as `"SBU"` are accepted. If your model uses different
-names, add them to `STATE_KEY_CANDIDATES` in `const.py` — see
-[API_CAPTURE.md](API_CAPTURE.md).
+> **Changed in 2.6.0.** This is the PI30 `PCP` code and it has **four** values.
+> Earlier releases mapped 0/1/2 onto CSO/SNU/OSO, which matches neither what the
+> device reports nor what it accepts — a device sitting on "Solar Only" (3)
+> could not be displayed at all.
 
 ---
 
 ## Switch Entities
 
-### Grid Charging (AC Input Range)
-**Entity:** `switch.{device}_grid_charging_ac_input_range`  
-**API key:** `acInputRangeSetting`
+| Entity | Reads | Writes | ON / OFF |
+|---|---|---|---|
+| `switch.{device}_backup_mode_sbu_priority` | `outputSourcePriority` | `settingDeviceOutputSourcePriority` | SBU (2) / SUB (1) |
+| `switch.{device}_solar_feed_to_grid` | `solarFeedToGrid` | `setGridConnectionStatus` | 1 / 0 |
+| `switch.{device}_buzzer` | `buzzerSetup` | `buzzerEnabled` | 1 / 0 |
+| `switch.{device}_overload_bypass` | `overloadBypassFunction` | `overloadBypass` | 1 / 0 |
+| `switch.{device}_overload_restart` | `overLoadRestart` | `overLoadRestartSetting` | 1 / 0 |
+| `switch.{device}_over_temperature_restart` | `overTemperatureRestart` | `overTemperatureRestartSetting` | 1 / 0 |
+| `switch.{device}_lcd_backlight` | `lcdBackLightControl` | `lcdBackLightControlSetting` | 1 / 0 |
+| `switch.{device}_lcd_return_to_default_page` | `lcdReturnToDefaultPage` | `lcdReturnToDefaultPageSetting` | 1 / 0 |
+| `switch.{device}_fault_code_recording` | `faultCodeRecord` | `faultCodeRecordSetting` | 1 / 0 |
+| `switch.{device}_alarm_on_primary_source_interrupt` | `alarmOnWhenPrimarySourceInterrupt` | `alarmOnWhenPrimarySourceInterruptSetting` | 1 / 0 |
 
-| State | API value | Behaviour |
-|---|---|---|
-| ON | 0 | **Appliance mode** — wide voltage range, grid charging allowed |
-| OFF | 1 | **UPS mode** — narrow voltage range, stricter bypass |
+> Backup Mode and Output Source Priority are the same device setting. Turning
+> Backup Mode ON moves the select to SBU, and vice versa.
 
-### Grid Feed-In
-**Entity:** `switch.{device}_grid_feed_in`  
-**API key:** `batteryPowerLimitingSetting`
+**Removed in 2.6.0:** *Grid Charging (AC Input Range)*. The device reports its
+input voltage range (`inputVoltageRange`: Appliance / UPS) but the portal
+exposes no write key for it, so the switch could never change anything. It is
+now the read-only *Input Voltage Range* diagnostic sensor.
 
-| State | API value | Behaviour |
-|---|---|---|
-| ON | 1 | Grid switch enabled — excess power exported to grid |
-| OFF | 0 | Grid switch disabled — no feed-in |
+---
 
-### Backup Mode (SBU Priority)
-**Entity:** `switch.{device}_backup_mode_sbu_priority`  
-**API key:** `outputSourcePrioritySetting`
+## Number Entities
 
-| State | API value | Behaviour |
-|---|---|---|
-| ON | 2 (SBU) | Solar+Battery first — battery reserved for outages |
-| OFF | 1 (SUB) | Solar first — grid supplements when solar is insufficient |
+| Entity | Reads | Writes | Range |
+|---|---|---|---|
+| `number.{device}_battery_equalization_voltage` | `batteryEqualizationVoltage` | `setBatteryEqualizationVoltage` | 20 – 60 V |
+| `number.{device}_battery_equalization_period` | `equalizationPeriod` | `setBatteryEqualizationPeriod` | 0 – 99 days |
+| `number.{device}_battery_equalization_timeout` | `equalizationOverTime` | `setBatteryEqualizationOverTime` | 0 – 900 min |
 
-> **Note:** Backup Mode and Output Source Priority share the same API key.
-> Turning Backup Mode ON changes Output Source Priority to SBU, and vice versa.
+**Removed in 2.6.0:** *Battery Charge Limit*, *Battery Discharge Limit* and
+*Grid Charge Limit*. No such attributes exist on PI30/VMIII and the write
+endpoint has no keys for them, so the sliders were permanently unavailable and
+their writes went nowhere. Charge and discharge current limits *are* reported
+(`optionalValueForMaximumChargingCurrent`, `maxDischargingCurren`) and are
+exposed as diagnostic sensors — the portal offers no way to write them.
 
 ---
 
@@ -133,19 +130,28 @@ automation:
           option: "Utility First (USO)"
 ```
 
-### Protect battery on cloudy days
+### Only charge from solar while the sun is up
 ```yaml
 automation:
-  - alias: "Solar — Raise discharge floor on low solar"
+  - alias: "Solar — Solar-only charging by day"
     trigger:
-      - platform: numeric_state
-        entity_id: sensor.1_inverter_pv_input_power
-        below: 50
-        for: "00:30:00"
+      - platform: sun
+        event: sunrise
     action:
-      - service: number.set_value
+      - service: select.select_option
         target:
-          entity_id: number.1_inverter_battery_discharge_limit
+          entity_id: select.1_inverter_charger_source_priority
         data:
-          value: 30
+          option: "Solar Only"
+
+  - alias: "Solar — Allow grid charging overnight"
+    trigger:
+      - platform: sun
+        event: sunset
+    action:
+      - service: select.select_option
+        target:
+          entity_id: select.1_inverter_charger_source_priority
+        data:
+          option: "Solar + Utility"
 ```

--- a/CONTROL_FEATURES.md
+++ b/CONTROL_FEATURES.md
@@ -54,6 +54,21 @@ Set to 0 to disable grid charging via this limit.
 | Solar First (SNU) | 1 | Solar charges the battery first; grid fills the shortfall |
 | Solar Only (OSO) | 2 | Only solar charges the battery; no grid charging |
 
+### How the current value is read back
+
+Writes go to `POST /apis/remote/device/config/write` under the `…Setting` key
+above. Reads do **not** come from the matching config cache: that cache only
+holds keys previously written through the portal, so it is empty on accounts
+that have never used remote control — which is why these selects reported
+`unknown` before 2.5.0.
+
+The current value is read from the live snapshot
+(`GET /apis/deviceState/simple/state/latest/v1`, fields `outputSourcePriority`
+and `chargerSourcePriority`), falling back to the config cache. Both an integer
+code and a label such as `"SBU"` are accepted. If your model uses different
+names, add them to `STATE_KEY_CANDIDATES` in `const.py` — see
+[API_CAPTURE.md](API_CAPTURE.md).
+
 ---
 
 ## Switch Entities

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The **Solar of Things** integration connects Home Assistant to the
 - **Auto-discovery** of every inverter under your station — enter your Station ID once and Home Assistant finds all devices automatically.
 - **10+ real-time sensors** updated every 5 minutes.
 - **4 monthly summary sensors** for energy totals and solar coverage.
-- **8 control entities** (sliders, dropdowns, switches) to manage battery limits, operating modes, and grid settings from HA.
+- **15 control entities** (dropdowns, switches, numbers) to manage charge/output priority, grid feed-in, and device behaviour from HA.
 - Full **Home Assistant Energy Dashboard** compatibility.
 - **Multi-station support** — add the integration once per station.
 
@@ -63,7 +63,7 @@ The **Solar of Things** integration connects Home Assistant to the
 | 🔍 **Auto-discovery** | Enter Station ID → HA fetches all device IDs automatically |
 | 📊 **Real-time monitoring** | 10 per-device sensors, updated every 5 min |
 | 📅 **Monthly statistics** | 4 station-level energy summary sensors |
-| 🎛️ **System control** | 8 control entities (battery limits, modes, grid switches) |
+| 🎛️ **System control** | 15 control entities (priorities, grid feed-in, device settings) |
 | ⚡ **Energy Dashboard** | All power and energy sensors are dashboard-ready |
 | 🏠 **Multi-station** | Unlimited stations via multiple config entries |
 | 🔒 **Secure auth** | User ID + Password with automatic token refresh |
@@ -86,7 +86,7 @@ The **Solar of Things** integration connects Home Assistant to the
 | `{device} Battery Voltage` | V | `voltage` | Battery bank terminal voltage |
 | `{device} Battery Power` | W | `power` | Net battery power (discharge − charge × voltage) |
 | `{device} Battery State of Charge` | % | `battery` | Battery charge level |
-| `{device} Grid Feed-in Power` | W | `power` | Power exported to the utility grid |
+| `{device} Grid Feed-in Power` | W | `power` | Power exported to the grid — reads 0 on off-grid models, which report no feed-in measurement |
 | `{device} Grid Import Power` | W | `power` | Power imported from the utility grid |
 | `{device} Load Power` | W | `power` | Total household / load consumption |
 
@@ -107,28 +107,35 @@ The **Solar of Things** integration connects Home Assistant to the
 > Controls require your device firmware/account to support the settings API.
 > If unresponsive, see [Troubleshooting](#troubleshooting).
 
-### Number Entities (Sliders)
+### Number Entities
 
 | Entity | Range | Step | Unit | Description |
 |---|---|---|---|---|
-| `{device} Battery Charge Limit` | 0 – 100 | 1 | % | Maximum SOC target for charging |
-| `{device} Battery Discharge Limit` | 0 – 100 | 1 | % | Minimum SOC before stopping discharge |
-| `{device} Grid Charge Limit` | 0 – 5000 | 100 | W | Max grid power used for battery charging |
+| `{device} Battery Equalization Voltage` | 20 – 60 | 0.1 | V | Equalization charge voltage |
+| `{device} Battery Equalization Period` | 0 – 99 | 1 | d | Days between equalization cycles |
+| `{device} Battery Equalization Timeout` | 0 – 900 | 5 | min | Maximum equalization duration |
 
 ### Select Entities (Dropdowns)
 
 | Entity | Options | Description |
 |---|---|---|
 | `{device} Output Source Priority` | Utility First (USO) · Solar First (SUB) · Solar+Battery First (SBU) | System power source priority |
-| `{device} Charger Source Priority` | Solar + Utility (CSO) · Solar First (SNU) · Solar Only (OSO) | Battery charging source priority |
+| `{device} Charger Source Priority` | Utility First · Solar First · Solar + Utility · Solar Only | Battery charging source priority |
 
 ### Switch Entities
 
 | Entity | Description |
 |---|---|
-| `{device} Grid Charging (AC Input Range)` | Allow/deny battery charging from the grid (Appliance vs UPS mode) |
-| `{device} Grid Feed-In` | Allow/deny exporting excess power to the grid |
 | `{device} Backup Mode (SBU Priority)` | Reserve battery capacity for power outages (SBU vs SUB priority) |
+| `{device} Solar Feed to Grid` | Allow/deny exporting excess solar to the grid |
+| `{device} Buzzer` | Audible alarm on/off |
+| `{device} Overload Bypass` | Pass the load through to the grid on overload |
+| `{device} Overload Restart` | Auto-restart after an overload shutdown |
+| `{device} Over-temperature Restart` | Auto-restart after a thermal shutdown |
+| `{device} LCD Backlight` | Front-panel backlight |
+| `{device} LCD Return to Default Page` | Return the panel to its default page |
+| `{device} Fault Code Recording` | Record fault codes on the device |
+| `{device} Alarm on Primary Source Interrupt` | Beep when the primary source drops |
 
 ---
 
@@ -244,17 +251,19 @@ automation:
             {{ states('sensor.1_inverter_battery_state_of_charge') }}%.
 ```
 
-### Enable grid charging at night
+### Allow grid charging at night
 ```yaml
 automation:
-  - alias: "Solar — Enable Grid Charging at Night"
+  - alias: "Solar — Allow Grid Charging at Night"
     trigger:
       - platform: time
         at: "22:00:00"
     action:
-      - service: switch.turn_on
+      - service: select.select_option
         target:
-          entity_id: switch.1_inverter_grid_charging_ac_input_range
+          entity_id: select.1_inverter_charger_source_priority
+        data:
+          option: "Solar + Utility"
 ```
 
 ### Switch to backup mode before a storm
@@ -273,11 +282,11 @@ automation:
       - service: switch.turn_on
         target:
           entity_id: switch.1_inverter_backup_mode_sbu_priority
-      - service: number.set_value
+      - service: select.select_option
         target:
-          entity_id: number.1_inverter_battery_charge_limit
+          entity_id: select.1_inverter_charger_source_priority
         data:
-          value: 95
+          option: "Solar + Utility"
 ```
 
 ---
@@ -310,13 +319,13 @@ entities:
     name: Output Mode
   - entity: select.1_inverter_charger_source_priority
     name: Charger Priority
-  - entity: number.1_inverter_battery_charge_limit
-  - entity: number.1_inverter_battery_discharge_limit
-  - entity: number.1_inverter_grid_charge_limit
   - type: divider
-  - entity: switch.1_inverter_grid_charging_ac_input_range
-  - entity: switch.1_inverter_grid_feed_in
   - entity: switch.1_inverter_backup_mode_sbu_priority
+  - entity: switch.1_inverter_solar_feed_to_grid
+  - entity: switch.1_inverter_buzzer
+  - type: divider
+  - entity: number.1_inverter_battery_equalization_voltage
+  - entity: number.1_inverter_battery_equalization_period
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -328,9 +328,18 @@ entities:
 | "Cannot Connect" on setup | Wrong credentials or network | Check User ID / password and HA network access to solar.siseli.com |
 | No devices discovered | Wrong Station ID | Verify 18-digit stationId in the portal Network tab |
 | Entities show "Unavailable" | Token expired or portal unreachable | HA will prompt re-auth automatically; check logs |
-| Sensors always "Unknown" | API returns null for that field | Normal for sensors not supported by your inverter model |
+| Sensors always "Unknown" | Your model publishes that measurement under another attribute name | Follow [API_CAPTURE.md](API_CAPTURE.md) so the name can be added |
+| Priority selects "Unknown" | Fixed in 2.5.0 — they used to read only the remote-config cache, which is empty until a setting is written through the portal | Update the integration |
 | Controls do nothing | Settings endpoint varies by firmware | Check HA logs for HTTP status codes |
 | Integration not in search | Files in wrong location | Verify `/config/custom_components/solar_of_things/` exists |
+
+### Reporting an "Unknown" entity
+
+The quickest fix path is **Settings → Devices & Services → Solar of Things →
+⋮ → Download diagnostics**, attached to a GitHub issue. It lists every
+attribute name your inverter publishes with credentials removed, which is all
+that is needed to map a missing value. See [API_CAPTURE.md](API_CAPTURE.md) for
+that and three other capture methods.
 
 ### Enable debug logging
 ```yaml

--- a/custom_components/solar_of_things/__init__.py
+++ b/custom_components/solar_of_things/__init__.py
@@ -271,9 +271,21 @@ class SolarOfThingsDeviceCoordinator(DataUpdateCoordinator):
             settings = await self.hass.async_add_executor_job(
                 self.api.fetch_settings, self.device_id
             )
+            try:
+                state = await self.hass.async_add_executor_job(
+                    self.api.fetch_state, self.device_id
+                )
+            except TokenExpiredError:
+                raise
+            except Exception as err:
+                _LOGGER.warning(
+                    "SolarOfThings device %s: state fetch failed: %s", self.device_id, err
+                )
+                state = {}
             return {
                 "time_series": time_series,
                 "settings": settings,
+                "state": state,
                 "device": self.device_id,
                 "station_id": self.station_id,
                 "device_meta": self.device_meta,

--- a/custom_components/solar_of_things/__init__.py
+++ b/custom_components/solar_of_things/__init__.py
@@ -34,7 +34,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .api import SolarOfThingsAPI, TokenExpiredError
+from .api import SolarOfThingsAPI, TokenExpiredError, merge_state_fallbacks
 from .const import (
     DOMAIN,
     CONF_USER_ID,
@@ -47,6 +47,7 @@ from .const import (
     CONF_ACCESS_TOKEN_EXPIRES,
     CONF_REFRESH_TOKEN_EXPIRES,
 )
+from .helpers import state_fields
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -256,11 +257,39 @@ class SolarOfThingsDeviceCoordinator(DataUpdateCoordinator):
         self.device_id = device
         self.device_meta = device_meta
         self._entry = entry
+        self._keys_logged = False
         super().__init__(
             hass,
             _LOGGER,
             name=f"{DOMAIN}_device_{device}",
             update_interval=DEVICE_UPDATE_INTERVAL,
+        )
+
+    def _log_available_keys(
+        self,
+        time_series: dict[str, Any],
+        settings: dict[str, Any],
+        state: dict[str, Any],
+    ) -> None:
+        """Log every attribute name this device exposes, once per HA run.
+
+        An entity that reads "unknown" almost always means the model publishes
+        the measurement under a name the integration does not know yet.  With
+        debug logging enabled these three lists show exactly which names are
+        available, so a missing one can be added to the candidate lists in
+        const.py (see API_CAPTURE.md).
+        """
+        if self._keys_logged or not _LOGGER.isEnabledFor(logging.DEBUG):
+            return
+        self._keys_logged = True
+        fields = state_fields(state)
+        _LOGGER.debug(
+            "SolarOfThings device %s attribute names — "
+            "time-series: %s | settings-cache: %s | state-snapshot: %s",
+            self.device_id,
+            sorted(time_series),
+            sorted(settings or {}),
+            sorted(fields),
         )
 
     async def _async_update_data(self) -> dict[str, Any]:
@@ -282,6 +311,15 @@ class SolarOfThingsDeviceCoordinator(DataUpdateCoordinator):
                     "SolarOfThings device %s: state fetch failed: %s", self.device_id, err
                 )
                 state = {}
+
+            # Logged before merging so each list shows what its own endpoint
+            # actually returned.
+            self._log_available_keys(time_series, settings, state)
+
+            # The time-series endpoint only returns the attribute names it
+            # knows; anything it omitted is filled from the live snapshot.
+            time_series = merge_state_fallbacks(time_series, state)
+
             return {
                 "time_series": time_series,
                 "settings": settings,

--- a/custom_components/solar_of_things/api.py
+++ b/custom_components/solar_of_things/api.py
@@ -856,3 +856,21 @@ class SolarOfThingsAPI:
         except Exception as err:
             _LOGGER.error("SolarOfThings: connection test failed: %s", err)
             return False
+
+    def fetch_state(self, device_id: str) -> dict[str, Any]:
+            """Fetch the full latest device state (all attribute fields + alarms)."""
+            from .const import API_STATE_LATEST
+            self._ensure_token_valid()
+            url = f"{API_BASE_URL}{API_STATE_LATEST}?deviceId={device_id}&dataSource=1"
+            resp = self.session.get(url, timeout=30)
+            if resp.status_code == 401:
+                self._access_expires = None
+                self._ensure_token_valid()
+                resp = self.session.get(url, timeout=30)
+            resp.raise_for_status()
+            data = resp.json()
+            if data.get("code") not in (0, None):
+                raise RuntimeError(
+                    f"State fetch error code={data.get('code')} message={data.get('message')}"
+                )
+            return data.get("data") or {}

--- a/custom_components/solar_of_things/api.py
+++ b/custom_components/solar_of_things/api.py
@@ -594,14 +594,14 @@ class SolarOfThingsAPI:
         end_time = self._now()
         start_time = end_time - timedelta(hours=1)
 
+        # Original keys + alternate attribute keys used by PI30 / VMIII
+        # (Voltronic-style) inverters. Whichever the model exposes is used.
         keys = [
-            "pvInputPower",
+            "pvInputPower", "generationPower", "PV1ChargingPower", "PV2ChargingPower",
             "acOutputActivePower",
-            "batteryDischargeCurrent",
-            "batteryChargingCurrent",
-            "batteryVoltage",
+            "batteryDischargeCurrent", "batteryChargingCurrent", "batteryVoltage",
+            "batterySOC", "batteryCapacity", "batteryPercentage",
             "feedInPower",
-            "batterySOC",
         ]
 
         data = self._post(
@@ -630,6 +630,32 @@ class SolarOfThingsAPI:
         for key, arr in fields.items():
             if isinstance(arr, list) and arr:
                 latest_values[key] = arr[-1]
+
+        # ── Model-dependent key resolution ──────────────────────────────────
+        # PV input power: pvInputPower, else generationPower (kW→W),
+        # else PV1+PV2 charging power (already W).
+        if latest_values.get("pvInputPower") in (None, ""):
+            if latest_values.get("generationPower") not in (None, ""):
+                try:
+                    latest_values["pvInputPower"] = float(latest_values["generationPower"]) * 1000.0
+                except Exception:
+                    pass
+            else:
+                try:
+                    pv1 = float(latest_values.get("PV1ChargingPower") or 0)
+                    pv2 = float(latest_values.get("PV2ChargingPower") or 0)
+                    if pv1 or pv2:
+                        latest_values["pvInputPower"] = pv1 + pv2
+                except Exception:
+                    pass
+
+        # Battery SOC: batterySOC, else batteryCapacity, else batteryPercentage.
+        if latest_values.get("batterySOC") in (None, ""):
+            soc = latest_values.get("batteryCapacity")
+            if soc in (None, ""):
+                soc = latest_values.get("batteryPercentage")
+            if soc not in (None, ""):
+                latest_values["batterySOC"] = soc
 
         # Unit normalisation: acOutputActivePower is kW in API → W
         if "acOutputActivePower" in latest_values:

--- a/custom_components/solar_of_things/api.py
+++ b/custom_components/solar_of_things/api.py
@@ -90,15 +90,29 @@ from .const import (
     API_MONTHLY_SUMMARY,
     API_DEVICE_LIST,
     API_SETTINGS_GET,
+    API_SETTINGS_READ,
+    API_SETTINGS_READ_DETAILS,
     API_SETTINGS_SET,
+    BOOLEAN_CONTROLS,
     CHARGER_PRIORITY_BY_VALUE,
     IOT_APP_ID,
     IOT_APP_SECRET_ENC,
+    NUMBER_CONTROLS,
     OUTPUT_PRIORITY_BY_VALUE,
+    SETTING_KEY_CANDIDATES,
     TELEMETRY_STATE_FALLBACKS,
     TOKEN_REFRESH_LEAD_SECONDS,
 )
-from .helpers import state_fields, state_number
+from .const import STATE_KEY_CANDIDATES
+from .helpers import (
+    entry_display,
+    entry_value,
+    find_entry,
+    normalise_text,
+    state_fields,
+    state_number,
+    to_float,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -269,7 +283,29 @@ def merge_state_fallbacks(
                 key, value,
             )
 
+    # Off-grid models (PI30/VMIII) have no feed-in measurement at all — they
+    # report only whether feeding the grid is permitted.  When it is switched
+    # off, feed-in is definitively zero, which is both true and what the
+    # derived grid-power figure needs; guessing "unknown" would be worse.
+    if latest.get("feedInPower") in (None, ""):
+        _key, entry = find_entry(fields, STATE_KEY_CANDIDATES["gridFeedIn"])
+        if entry is not None and not _feed_in_enabled(entry):
+            latest["feedInPower"] = 0.0
+
     return compute_derived_values(latest)
+
+
+def _feed_in_enabled(entry: Any) -> bool:
+    """Return True unless the solar-feed-to-grid setting reads as disabled."""
+    number = to_float(entry_value(entry))
+    if number is not None:
+        return number != 0
+    return normalise_text(entry_display(entry) or entry_value(entry)) not in {
+        "disable",
+        "disabled",
+        "off",
+        "no",
+    }
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -660,13 +696,14 @@ class SolarOfThingsAPI:
 
         # Original keys + alternate attribute keys used by PI30 / VMIII
         # (Voltronic-style) inverters. Whichever the model exposes is used.
+        # Superset of the names seen across models — the endpoint simply omits
+        # the ones this device does not record.  Anything missing here is filled
+        # from the state snapshot afterwards (see merge_state_fallbacks).
         keys = [
             "pvInputPower", "generationPower", "PV1ChargingPower", "PV2ChargingPower",
             "acOutputActivePower",
             "batteryDischargeCurrent", "batteryChargingCurrent", "batteryVoltage",
             "batterySOC", "batteryCapacity", "batteryPercentage",
-            # Feed-in is named differently across models; request every variant
-            # we know of — the endpoint simply omits the ones it doesn't have.
             "feedInPower", "gridFeedInPower", "feedInActivePower", "onGridPower",
         ]
 
@@ -812,10 +849,16 @@ class SolarOfThingsAPI:
     # than in the JSON body.
 
     def _write_setting(self, device_id: str, key: str, value: Any) -> None:
-        """Write a single device setting key=value via the remote config write API."""
+        """Write a single device setting key=value via the remote config write API.
+
+        The body field is ``id``, not ``deviceId`` — captured from the portal's
+        own control panel.  Releases before 2.6.0 sent ``deviceId`` here, which
+        the endpoint accepts with a success code while changing nothing.
+        """
         self._ensure_token_valid()
         url = f"{API_BASE_URL}{API_SETTINGS_SET}?deviceId={device_id}"
-        payload = {"deviceId": device_id, "key": key, "value": value}
+        payload = {"id": device_id, "key": key, "value": value}
+        _LOGGER.debug("SolarOfThings: writing %s=%r to %s", key, value, device_id)
         resp = self.session.post(url, json=payload, timeout=30)
         resp.raise_for_status()
         data = resp.json()
@@ -852,12 +895,11 @@ class SolarOfThingsAPI:
         for key, value in settings.items():
             self._write_setting(device_id, key, value)
 
-    # ─── Convenience control helpers (called by select.py / switch.py) ─────────
-    # Key names are the real device attribute keys returned by get_device_settings.
-    # Output Source Priority:   USO=0, SUB=1, SBU=2
-    # Charger Source Priority:  CSO=0, SNU=1, OSO=2
-    # batteryPowerLimitingSetting: 0=OFF, 1=ON  (GRID switch)
-    # acInputRangeSetting:         0=Appliance, 1=UPS
+    # ─── Control helpers (called by select.py / switch.py / number.py) ────────
+    # Writes go to POST /apis/remote/device/config/write with the *setting* key
+    # names (settingDevice…), which differ from the state-snapshot names the
+    # entities read back from.  Enum values are sent as strings, matching what
+    # the portal's own control panel sends.
 
     # Option-string → integer maps, inverted from the single definition in
     # const.py so the write path and the select read-back cannot drift apart.
@@ -867,13 +909,24 @@ class SolarOfThingsAPI:
     _CHARGER_PRIORITY_REVERSE: dict[int, str] = CHARGER_PRIORITY_BY_VALUE
     _CHARGER_PRIORITY_MAP: dict[str, int] = {v: k for k, v in CHARGER_PRIORITY_BY_VALUE.items()}
 
+    def _write_control(self, device_id: str, control: str, value: Any) -> None:
+        """Write a logical control by its name in ``SETTING_KEY_CANDIDATES``.
+
+        The first candidate is the name this firmware family uses; the rest are
+        older names kept for models that still answer to them.
+        """
+        candidates = SETTING_KEY_CANDIDATES.get(control)
+        if not candidates:
+            raise ValueError(f"Unknown control {control!r}")
+        self._write_setting(device_id, candidates[0], value)
+
     def set_operating_mode(self, device_id: str, mode: str) -> None:
         """Set Output Source Priority.  mode is one of _OUTPUT_MODE_MAP keys."""
         value = self._OUTPUT_MODE_MAP.get(mode)
         if value is None:
             raise ValueError(f"Unknown operating mode: {mode!r}. "
                              f"Valid options: {list(self._OUTPUT_MODE_MAP)!r}")
-        self._write_setting(device_id, "outputSourcePrioritySetting", value)
+        self._write_control(device_id, "outputSourcePriority", str(value))
 
     def set_battery_priority(self, device_id: str, mode: str) -> None:
         """Set Charger Source Priority.  mode is one of _CHARGER_PRIORITY_MAP keys."""
@@ -881,33 +934,75 @@ class SolarOfThingsAPI:
         if value is None:
             raise ValueError(f"Unknown battery priority: {mode!r}. "
                              f"Valid options: {list(self._CHARGER_PRIORITY_MAP)!r}")
-        self._write_setting(device_id, "chargerSourcePrioritySetting", value)
+        self._write_control(device_id, "chargerSourcePriority", str(value))
 
-    def set_grid_charging(self, device_id: str, enabled: bool) -> None:
-        """Set AC Input Range: Appliance (0, grid charging allowed) / UPS (1, bypass)."""
-        self._write_setting(device_id, "acInputRangeSetting", 0 if enabled else 1)
+    def set_boolean_control(self, device_id: str, control: str, enabled: bool) -> None:
+        """Toggle one of the BOOLEAN_CONTROLS entries."""
+        spec = BOOLEAN_CONTROLS.get(control)
+        if spec is None:
+            raise ValueError(f"Unknown boolean control {control!r}")
+        self._write_control(device_id, control, spec["on_value"] if enabled else spec["off_value"])
+
+    def set_number_control(self, device_id: str, control: str, value: float) -> None:
+        """Write one of the NUMBER_CONTROLS entries.
+
+        Numeric settings are sent as numbers (the portal sends 120, 29.2 …);
+        anything else goes out as a string.
+        """
+        spec = NUMBER_CONTROLS.get(control)
+        if spec is None:
+            raise ValueError(f"Unknown number control {control!r}")
+        if spec.get("numeric", True):
+            payload_value: Any = int(value) if float(value).is_integer() else float(value)
+        else:
+            payload_value = str(value)
+        self._write_control(device_id, control, payload_value)
 
     def set_grid_feed_in(self, device_id: str, enabled: bool) -> None:
-        """Enable or disable the GRID grid switch (batteryPowerLimitingSetting)."""
-        self._write_setting(device_id, "batteryPowerLimitingSetting", 1 if enabled else 0)
+        """Enable or disable feeding solar back to the grid."""
+        self.set_boolean_control(device_id, "gridFeedIn", enabled)
 
     def set_backup_mode(self, device_id: str, enabled: bool) -> None:
         """Set Output Source Priority to SBU (backup/off-grid priority) when True,
         or SUB (solar-first, grid-supplemented) when False."""
-        value = 2 if enabled else 1   # SBU=2 (battery before grid), SUB=1
-        self._write_setting(device_id, "outputSourcePrioritySetting", value)
+        self.set_operating_mode(
+            device_id,
+            OUTPUT_PRIORITY_BY_VALUE[2] if enabled else OUTPUT_PRIORITY_BY_VALUE[1],
+        )
 
-    def set_battery_charge_limit(self, device_id: str, percent: int) -> None:
-        """Set battery charge limit (0–100 %)."""
-        self._write_setting(device_id, "batteryChargeLimit", percent)
+    def request_config_read(self, device_id: str) -> str | None:
+        """Ask the device to report its remote-config values (portal "Batch Read").
 
-    def set_battery_discharge_limit(self, device_id: str, percent: int) -> None:
-        """Set battery discharge limit / minimum SOC (0–100 %)."""
-        self._write_setting(device_id, "batteryDischargeLimit", percent)
+        Returns the batch id, which ``fetch_config_read_details`` can poll.  The
+        round-trip goes out to the inverter, so results appear seconds later —
+        the integration does not depend on it, since the live state snapshot
+        already carries every current value.
+        """
+        self._ensure_token_valid()
+        url = f"{API_BASE_URL}{API_SETTINGS_READ}?deviceId={device_id}"
+        resp = self.session.post(url, json={}, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        if data.get("code") not in (0, None):
+            raise RuntimeError(
+                f"Config read request failed code={data.get('code')} "
+                f"message={data.get('message')}"
+            )
+        return (data.get("data") or {}).get("id")
 
-    def set_grid_charge_limit(self, device_id: str, watts: int) -> None:
-        """Set maximum grid charge power (0–5000 W)."""
-        self._write_setting(device_id, "gridChargeLimit", watts)
+    def fetch_config_read_details(self, batch_read_id: str) -> dict[str, Any]:
+        """Return the result of a ``request_config_read`` batch."""
+        self._ensure_token_valid()
+        url = f"{API_BASE_URL}{API_SETTINGS_READ_DETAILS}?batchReadId={batch_read_id}"
+        resp = self.session.get(url, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        if data.get("code") not in (0, None):
+            raise RuntimeError(
+                f"Config read details failed code={data.get('code')} "
+                f"message={data.get('message')}"
+            )
+        return data.get("data") or {}
 
     def test_connection(self, station_id: str) -> bool:
         """Return True if we can reach the device-list endpoint successfully."""

--- a/custom_components/solar_of_things/api.py
+++ b/custom_components/solar_of_things/api.py
@@ -91,10 +91,14 @@ from .const import (
     API_DEVICE_LIST,
     API_SETTINGS_GET,
     API_SETTINGS_SET,
+    CHARGER_PRIORITY_BY_VALUE,
     IOT_APP_ID,
     IOT_APP_SECRET_ENC,
+    OUTPUT_PRIORITY_BY_VALUE,
+    TELEMETRY_STATE_FALLBACKS,
     TOKEN_REFRESH_LEAD_SECONDS,
 )
+from .helpers import state_fields, state_number
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -206,6 +210,66 @@ def _parse_expiry(value: str | None) -> datetime | None:
         return dt.astimezone(timezone.utc)
     except Exception:
         return None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Telemetry assembly
+# ──────────────────────────────────────────────────────────────────────────────
+
+def compute_derived_values(values: dict[str, Any]) -> dict[str, Any]:
+    """Fill in batteryPower / gridPower / loadPower from the raw measurements.
+
+    Idempotent, so it can be re-run after the state-snapshot fallbacks have
+    supplied keys that the time-series endpoint did not return.
+    """
+    def _num(key: str) -> float:
+        try:
+            return float(values.get(key) or 0)
+        except (TypeError, ValueError):
+            return 0.0
+
+    voltage = _num("batteryVoltage")
+    discharge = _num("batteryDischargeCurrent")
+    charge = _num("batteryChargingCurrent")
+    values["batteryPower"] = (discharge - charge) * voltage
+
+    pv_power = _num("pvInputPower")
+    ac_output = _num("acOutputActivePower")
+    feed_in = _num("feedInPower")
+    battery_power = _num("batteryPower")
+
+    values["gridPower"] = max(0.0, ac_output - pv_power + battery_power + feed_in)
+    values["loadPower"] = ac_output
+    return values
+
+
+def merge_state_fallbacks(
+    latest: dict[str, Any], state: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Fill telemetry keys the time-series endpoint omitted from the snapshot.
+
+    The history endpoint only returns keys the model actually records under the
+    exact name we asked for, so measurements such as ``feedInPower`` come back
+    empty on inverters that publish them under a different attribute name.  The
+    state/latest snapshot carries every attribute the device reports, so we use
+    it as the fallback source and then recompute the derived values.
+    """
+    fields = state_fields(state)
+    if not fields:
+        return latest
+
+    for key, (candidates, kind) in TELEMETRY_STATE_FALLBACKS.items():
+        if latest.get(key) not in (None, ""):
+            continue
+        value = state_number(fields, candidates, kind)
+        if value is not None:
+            latest[key] = value
+            _LOGGER.debug(
+                "SolarOfThings: %s not in time-series; using state snapshot (%s)",
+                key, value,
+            )
+
+    return compute_derived_values(latest)
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -601,7 +665,9 @@ class SolarOfThingsAPI:
             "acOutputActivePower",
             "batteryDischargeCurrent", "batteryChargingCurrent", "batteryVoltage",
             "batterySOC", "batteryCapacity", "batteryPercentage",
-            "feedInPower",
+            # Feed-in is named differently across models; request every variant
+            # we know of — the endpoint simply omits the ones it doesn't have.
+            "feedInPower", "gridFeedInPower", "feedInActivePower", "onGridPower",
         ]
 
         data = self._post(
@@ -657,6 +723,21 @@ class SolarOfThingsAPI:
             if soc not in (None, ""):
                 latest_values["batterySOC"] = soc
 
+        # Remaining aliases: the history endpoint returns whichever attribute
+        # name the model records, so normalise the known alternates onto our
+        # canonical keys.  Values from this endpoint share the canonical key's
+        # unit, so no scaling is applied here (the kW cases above are explicit).
+        for canonical, (candidates, _kind) in TELEMETRY_STATE_FALLBACKS.items():
+            if latest_values.get(canonical) not in (None, ""):
+                continue
+            for alias in candidates:
+                if alias == canonical:
+                    continue
+                value = latest_values.get(alias)
+                if value not in (None, ""):
+                    latest_values[canonical] = value
+                    break
+
         # Unit normalisation: acOutputActivePower is kW in API → W
         if "acOutputActivePower" in latest_values:
             try:
@@ -666,19 +747,7 @@ class SolarOfThingsAPI:
             except Exception:
                 pass
 
-        # Derived values
-        voltage = float(latest_values.get("batteryVoltage") or 0)
-        discharge = float(latest_values.get("batteryDischargeCurrent") or 0)
-        charge = float(latest_values.get("batteryChargingCurrent") or 0)
-        latest_values["batteryPower"] = (discharge - charge) * voltage
-
-        pv_power = float(latest_values.get("pvInputPower") or 0)
-        ac_output = float(latest_values.get("acOutputActivePower") or 0)
-        feed_in = float(latest_values.get("feedInPower") or 0)
-        battery_power = float(latest_values.get("batteryPower") or 0)
-
-        latest_values["gridPower"] = max(0.0, ac_output - pv_power + battery_power + feed_in)
-        latest_values["loadPower"] = ac_output
+        compute_derived_values(latest_values)
 
         return latest_values
 
@@ -790,21 +859,13 @@ class SolarOfThingsAPI:
     # batteryPowerLimitingSetting: 0=OFF, 1=ON  (GRID switch)
     # acInputRangeSetting:         0=Appliance, 1=UPS
 
-    # Operating-mode select maps HA option strings to integer values
-    _OUTPUT_MODE_MAP: dict[str, int] = {
-        "Utility First (USO)": 0,
-        "Solar First (SUB)": 1,
-        "Solar+Battery First (SBU)": 2,
-    }
-    _OUTPUT_MODE_REVERSE: dict[int, str] = {v: k for k, v in _OUTPUT_MODE_MAP.items()}
+    # Option-string → integer maps, inverted from the single definition in
+    # const.py so the write path and the select read-back cannot drift apart.
+    _OUTPUT_MODE_REVERSE: dict[int, str] = OUTPUT_PRIORITY_BY_VALUE
+    _OUTPUT_MODE_MAP: dict[str, int] = {v: k for k, v in OUTPUT_PRIORITY_BY_VALUE.items()}
 
-    # Charger-priority select
-    _CHARGER_PRIORITY_MAP: dict[str, int] = {
-        "Solar + Utility (CSO)": 0,
-        "Solar First (SNU)": 1,
-        "Solar Only (OSO)": 2,
-    }
-    _CHARGER_PRIORITY_REVERSE: dict[int, str] = {v: k for k, v in _CHARGER_PRIORITY_MAP.items()}
+    _CHARGER_PRIORITY_REVERSE: dict[int, str] = CHARGER_PRIORITY_BY_VALUE
+    _CHARGER_PRIORITY_MAP: dict[str, int] = {v: k for k, v in CHARGER_PRIORITY_BY_VALUE.items()}
 
     def set_operating_mode(self, device_id: str, mode: str) -> None:
         """Set Output Source Priority.  mode is one of _OUTPUT_MODE_MAP keys."""

--- a/custom_components/solar_of_things/const.py
+++ b/custom_components/solar_of_things/const.py
@@ -44,6 +44,7 @@ API_MONTHLY_SUMMARY = "/apis/stationOverView/stateAttributeSummary/category/year
 API_SETTINGS_GET   = "/apis/remote/device/configs/cache/get"  # ?deviceId=<id>
 API_SETTINGS_SET   = "/apis/remote/device/config/write"       # ?deviceId=<id>
 API_DEVICE_LIST    = "/apis/device/list"
+API_STATE_LATEST   = "/apis/deviceState/simple/state/latest/v1"
 
 # ─── Token refresh window ──────────────────────────────────────────────────────
 # Refresh the access token this many seconds *before* its stated expiry.

--- a/custom_components/solar_of_things/const.py
+++ b/custom_components/solar_of_things/const.py
@@ -51,6 +51,164 @@ API_STATE_LATEST   = "/apis/deviceState/simple/state/latest/v1"
 # Mirrors the portal JS which refreshes when ≤300 s remain.
 TOKEN_REFRESH_LEAD_SECONDS = 300  # 5 minutes
 
+# ─── Attribute-key candidates ──────────────────────────────────────────────────
+# Inverter models expose the same measurement under different attribute names
+# (and the state endpoint is inconsistent about capitalisation), so every lookup
+# tries a list of candidates case-insensitively.  Add a name here when a new
+# model reports one we do not know about yet — see API_CAPTURE.md for how to
+# find out which names your device actually uses.
+
+# Setting keys written through /apis/remote/device/config/write.
+SETTING_KEY_CANDIDATES: dict[str, list[str]] = {
+    "outputSourcePriority": [
+        "outputSourcePrioritySetting",
+        "outputSourcePriority",
+        "outputPrioritySetting",
+        "outputPriority",
+    ],
+    "chargerSourcePriority": [
+        "chargerSourcePrioritySetting",
+        "chargerSourcePriority",
+        "chargeSourcePrioritySetting",
+        "chargerPrioritySetting",
+        "chargingSourcePriority",
+    ],
+    "acInputRange": [
+        "acInputRangeSetting",
+        "acInputRange",
+        "inputVoltageRangeSetting",
+    ],
+    "gridFeedIn": [
+        "batteryPowerLimitingSetting",
+        "feedInGridSetting",
+        "gridFeedInSetting",
+    ],
+    "batteryChargeLimit": ["batteryChargeLimit", "batteryChargeLimitSetting"],
+    "batteryDischargeLimit": ["batteryDischargeLimit", "batteryDischargeLimitSetting"],
+    "gridChargeLimit": ["gridChargeLimit", "gridChargeLimitSetting", "maxUtilityChargingCurrent"],
+}
+
+# Live-snapshot field names from /apis/deviceState/simple/state/latest/v1.
+# The snapshot carries the *current* device state, which is what the selects and
+# switches read back — unlike the settings cache, which only holds values that
+# were previously written through the portal.
+STATE_KEY_CANDIDATES: dict[str, list[str]] = {
+    "outputSourcePriority": [
+        "outputSourcePriority",
+        "outputSourcePrioritySetting",
+        "outputPriority",
+        "outputSourcePriorityStatus",
+        "outputMode",
+    ],
+    "chargerSourcePriority": [
+        "chargerSourcePriority",
+        "chargerSourcePrioritySetting",
+        "chargeSourcePriority",
+        "chargerPriority",
+        "chargingSourcePriority",
+    ],
+    "acInputRange": ["acInputRange", "acInputRangeSetting", "inputVoltageRange"],
+    "gridFeedIn": [
+        "batteryPowerLimiting",
+        "batteryPowerLimitingSetting",
+        "feedInGrid",
+        "gridFeedIn",
+    ],
+    "batteryChargeLimit": ["batteryChargeLimit", "batteryChargeLimitSetting"],
+    "batteryDischargeLimit": ["batteryDischargeLimit", "batteryDischargeLimitSetting"],
+    "gridChargeLimit": ["gridChargeLimit", "maxUtilityChargingCurrent"],
+}
+
+# Telemetry keys that the time-series endpoint may not return for a given model.
+# When a key is missing there we fall back to the state snapshot, which reports
+# every attribute the device publishes.  Each entry is (candidates, kind); kind
+# drives unit normalisation ("power" → W, "energy" → kWh, None → as-is).
+TELEMETRY_STATE_FALLBACKS: dict[str, tuple[list[str], str | None]] = {
+    "pvInputPower": (
+        ["pvInputPower", "pvChargingPower", "PV1ChargingPower", "generationPower"],
+        "power",
+    ),
+    "acOutputActivePower": (
+        ["acOutputActivePower", "acOutputPower", "outputActivePower", "loadActivePower"],
+        "power",
+    ),
+    "feedInPower": (
+        [
+            "feedInPower",
+            "gridFeedInPower",
+            "feedInActivePower",
+            "acFeedInPower",
+            "feedbackPower",
+            "gridExportPower",
+            "exportPower",
+            "onGridPower",
+            "gridConnectedPower",
+        ],
+        "power",
+    ),
+    "batteryVoltage": (["batteryVoltage", "batteryTerminalVoltage"], None),
+    "batteryChargingCurrent": (
+        ["batteryChargingCurrent", "batteryChargeCurrent"],
+        None,
+    ),
+    "batteryDischargeCurrent": (
+        ["batteryDischargeCurrent", "batteryDischargingCurrent"],
+        None,
+    ),
+    "batterySOC": (
+        ["batterySOC", "batteryCapacity", "batteryPercentage", "soc"],
+        None,
+    ),
+}
+
+# ─── Control option maps ───────────────────────────────────────────────────────
+# Output Source Priority (outputSourcePrioritySetting): 0=USO, 1=SUB, 2=SBU.
+OUTPUT_PRIORITY_BY_VALUE: dict[int, str] = {
+    0: "Utility First (USO)",
+    1: "Solar First (SUB)",
+    2: "Solar+Battery First (SBU)",
+}
+OUTPUT_PRIORITY_OPTIONS: list[str] = list(OUTPUT_PRIORITY_BY_VALUE.values())
+
+# Alias table for resolving a text value/valueDisplay onto an option.  Keys are
+# normalised (lowercase, non-alphanumerics collapsed to single spaces).
+OUTPUT_PRIORITY_ALIASES: dict[str, str] = {
+    "uso": OUTPUT_PRIORITY_BY_VALUE[0],
+    "utility": OUTPUT_PRIORITY_BY_VALUE[0],
+    "utility first": OUTPUT_PRIORITY_BY_VALUE[0],
+    "utility priority": OUTPUT_PRIORITY_BY_VALUE[0],
+    "grid first": OUTPUT_PRIORITY_BY_VALUE[0],
+    "sub": OUTPUT_PRIORITY_BY_VALUE[1],
+    "solar first": OUTPUT_PRIORITY_BY_VALUE[1],
+    "solar priority": OUTPUT_PRIORITY_BY_VALUE[1],
+    "solar utility battery": OUTPUT_PRIORITY_BY_VALUE[1],
+    "sbu": OUTPUT_PRIORITY_BY_VALUE[2],
+    "battery first": OUTPUT_PRIORITY_BY_VALUE[2],
+    "solar battery first": OUTPUT_PRIORITY_BY_VALUE[2],
+    "solar battery utility": OUTPUT_PRIORITY_BY_VALUE[2],
+}
+
+# Charger Source Priority (chargerSourcePrioritySetting): 0=CSO, 1=SNU, 2=OSO.
+CHARGER_PRIORITY_BY_VALUE: dict[int, str] = {
+    0: "Solar + Utility (CSO)",
+    1: "Solar First (SNU)",
+    2: "Solar Only (OSO)",
+}
+CHARGER_PRIORITY_OPTIONS: list[str] = list(CHARGER_PRIORITY_BY_VALUE.values())
+
+CHARGER_PRIORITY_ALIASES: dict[str, str] = {
+    "cso": CHARGER_PRIORITY_BY_VALUE[0],
+    "solar utility": CHARGER_PRIORITY_BY_VALUE[0],
+    "solar and utility": CHARGER_PRIORITY_BY_VALUE[0],
+    "utility first": CHARGER_PRIORITY_BY_VALUE[0],
+    "snu": CHARGER_PRIORITY_BY_VALUE[1],
+    "solar first": CHARGER_PRIORITY_BY_VALUE[1],
+    "solar priority": CHARGER_PRIORITY_BY_VALUE[1],
+    "oso": CHARGER_PRIORITY_BY_VALUE[2],
+    "solar only": CHARGER_PRIORITY_BY_VALUE[2],
+    "only solar": CHARGER_PRIORITY_BY_VALUE[2],
+}
+
 # ─── Sensor keys ───────────────────────────────────────────────────────────────
 SENSOR_KEYS = [
     "pvInputPower",

--- a/custom_components/solar_of_things/const.py
+++ b/custom_components/solar_of_things/const.py
@@ -43,6 +43,10 @@ API_MONTHLY_SUMMARY = "/apis/stationOverView/stateAttributeSummary/category/year
 # as a query parameter.  Write sends one setting key+value per call.
 API_SETTINGS_GET   = "/apis/remote/device/configs/cache/get"  # ?deviceId=<id>
 API_SETTINGS_SET   = "/apis/remote/device/config/write"       # ?deviceId=<id>
+# Portal "Batch Read": asks the inverter to report its config, then poll the
+# details endpoint with the returned batch id.
+API_SETTINGS_READ         = "/apis/remote/device/configs/read"          # ?deviceId=<id>
+API_SETTINGS_READ_DETAILS = "/apis/remote/device/configs/read/details"  # ?batchReadId=<id>
 API_DEVICE_LIST    = "/apis/device/list"
 API_STATE_LATEST   = "/apis/deviceState/simple/state/latest/v1"
 
@@ -51,118 +55,96 @@ API_STATE_LATEST   = "/apis/deviceState/simple/state/latest/v1"
 # Mirrors the portal JS which refreshes when ≤300 s remain.
 TOKEN_REFRESH_LEAD_SECONDS = 300  # 5 minutes
 
-# ─── Attribute-key candidates ──────────────────────────────────────────────────
-# Inverter models expose the same measurement under different attribute names
-# (and the state endpoint is inconsistent about capitalisation), so every lookup
-# tries a list of candidates case-insensitively.  Add a name here when a new
-# model reports one we do not know about yet — see API_CAPTURE.md for how to
-# find out which names your device actually uses.
+# ─── Attribute names ───────────────────────────────────────────────────────────
+# All names below were captured from a live PI30 / VMIII inverter on
+# solar.siseli.com (see API_CAPTURE.md).  Lookups match case-insensitively and
+# try each candidate in order, so a model that uses a different name only needs
+# that name appended to the relevant list.
+#
+# The portal uses three different name spaces for the same control:
+#
+#   read  (live)   state/latest field       e.g. "chargerSourcePriority"
+#   read  (cache)  remote-config cache key  e.g. "settingDeviceChargerPriority"
+#   write          config/write key         e.g. "settingDeviceChargerPriority"
+#
+# The cache is only populated after a remote read/write round-trip, so the live
+# snapshot is what the integration reads and the write keys are separate.
 
-# Setting keys written through /apis/remote/device/config/write.
+# Keys accepted by POST /apis/remote/device/config/write.
 SETTING_KEY_CANDIDATES: dict[str, list[str]] = {
     "outputSourcePriority": [
+        "settingDeviceOutputSourcePriority",
+        # Pre-2.6 name, kept so a firmware that still accepts it keeps working.
         "outputSourcePrioritySetting",
-        "outputSourcePriority",
-        "outputPrioritySetting",
-        "outputPriority",
     ],
     "chargerSourcePriority": [
+        "settingDeviceChargerPriority",
         "chargerSourcePrioritySetting",
-        "chargerSourcePriority",
-        "chargeSourcePrioritySetting",
-        "chargerPrioritySetting",
-        "chargingSourcePriority",
     ],
-    "acInputRange": [
-        "acInputRangeSetting",
-        "acInputRange",
-        "inputVoltageRangeSetting",
-    ],
-    "gridFeedIn": [
-        "batteryPowerLimitingSetting",
-        "feedInGridSetting",
-        "gridFeedInSetting",
-    ],
-    "batteryChargeLimit": ["batteryChargeLimit", "batteryChargeLimitSetting"],
-    "batteryDischargeLimit": ["batteryDischargeLimit", "batteryDischargeLimitSetting"],
-    "gridChargeLimit": ["gridChargeLimit", "gridChargeLimitSetting", "maxUtilityChargingCurrent"],
+    "gridFeedIn": ["setGridConnectionStatus"],
+    "buzzer": ["buzzerEnabled"],
+    "overloadBypass": ["overloadBypass"],
+    "overLoadRestart": ["overLoadRestartSetting"],
+    "overTemperatureRestart": ["overTemperatureRestartSetting"],
+    "lcdBacklight": ["lcdBackLightControlSetting"],
+    "lcdReturnToDefaultPage": ["lcdReturnToDefaultPageSetting"],
+    "faultCodeRecord": ["faultCodeRecordSetting"],
+    "alarmOnPrimarySourceInterrupt": ["alarmOnWhenPrimarySourceInterruptSetting"],
+    "equalizationVoltage": ["setBatteryEqualizationVoltage"],
+    "equalizationPeriod": ["setBatteryEqualizationPeriod"],
+    "equalizationOverTime": ["setBatteryEqualizationOverTime"],
+    "outputRatingFrequency": ["settingInverterOutputRatingFrequency"],
 }
 
-# Live-snapshot field names from /apis/deviceState/simple/state/latest/v1.
-# The snapshot carries the *current* device state, which is what the selects and
-# switches read back — unlike the settings cache, which only holds values that
-# were previously written through the portal.
+# Field names in GET /apis/deviceState/simple/state/latest/v1 — the live
+# snapshot, and the source every control reads its current value from.
 STATE_KEY_CANDIDATES: dict[str, list[str]] = {
-    "outputSourcePriority": [
-        "outputSourcePriority",
-        "outputSourcePrioritySetting",
-        "outputPriority",
-        "outputSourcePriorityStatus",
-        "outputMode",
-    ],
-    "chargerSourcePriority": [
-        "chargerSourcePriority",
-        "chargerSourcePrioritySetting",
-        "chargeSourcePriority",
-        "chargerPriority",
-        "chargingSourcePriority",
-    ],
-    "acInputRange": ["acInputRange", "acInputRangeSetting", "inputVoltageRange"],
-    "gridFeedIn": [
-        "batteryPowerLimiting",
-        "batteryPowerLimitingSetting",
-        "feedInGrid",
-        "gridFeedIn",
-    ],
-    "batteryChargeLimit": ["batteryChargeLimit", "batteryChargeLimitSetting"],
-    "batteryDischargeLimit": ["batteryDischargeLimit", "batteryDischargeLimitSetting"],
-    "gridChargeLimit": ["gridChargeLimit", "maxUtilityChargingCurrent"],
+    "outputSourcePriority": ["outputSourcePriority", "outputSourcePrioritySetting"],
+    "chargerSourcePriority": ["chargerSourcePriority", "chargeSourcePriority"],
+    "gridFeedIn": ["solarFeedToGrid", "gridConnectionStatus", "feedInGrid"],
+    "acInputRange": ["inputVoltageRange", "acInputRange"],
+    "buzzer": ["buzzerSetup", "buzzerEnabled"],
+    "overloadBypass": ["overloadBypassFunction", "overloadBypass"],
+    "overLoadRestart": ["overLoadRestart"],
+    "overTemperatureRestart": ["overTemperatureRestart"],
+    "lcdBacklight": ["lcdBackLightControl"],
+    "lcdReturnToDefaultPage": ["lcdReturnToDefaultPage"],
+    "faultCodeRecord": ["faultCodeRecord"],
+    "alarmOnPrimarySourceInterrupt": ["alarmOnWhenPrimarySourceInterrupt"],
+    "equalizationVoltage": ["batteryEqualizationVoltage"],
+    "equalizationPeriod": ["equalizationPeriod"],
+    "equalizationOverTime": ["equalizationOverTime"],
+    "outputRatingFrequency": ["acOutputRatingFrequency"],
 }
 
-# Telemetry keys that the time-series endpoint may not return for a given model.
-# When a key is missing there we fall back to the state snapshot, which reports
-# every attribute the device publishes.  Each entry is (candidates, kind); kind
-# drives unit normalisation ("power" → W, "energy" → kWh, None → as-is).
+# Telemetry keys the time-series endpoint may not return for a given model.
+# Filled from the state snapshot instead; each entry is (candidates, kind), and
+# kind drives unit normalisation ("power" → W, "energy" → kWh, None → as-is)
+# using the unit the snapshot reports alongside the value.
 TELEMETRY_STATE_FALLBACKS: dict[str, tuple[list[str], str | None]] = {
+    # PI30/VMIII reports PV power as generationPower in kW.
     "pvInputPower": (
-        ["pvInputPower", "pvChargingPower", "PV1ChargingPower", "generationPower"],
+        ["pvInputPower", "generationPower", "pvChargingPower", "PV1ChargingPower"],
         "power",
     ),
     "acOutputActivePower": (
-        ["acOutputActivePower", "acOutputPower", "outputActivePower", "loadActivePower"],
+        ["acOutputActivePower", "acOutputPower", "outputActivePower"],
         "power",
     ),
     "feedInPower": (
-        [
-            "feedInPower",
-            "gridFeedInPower",
-            "feedInActivePower",
-            "acFeedInPower",
-            "feedbackPower",
-            "gridExportPower",
-            "exportPower",
-            "onGridPower",
-            "gridConnectedPower",
-        ],
+        ["feedInPower", "gridFeedInPower", "feedInActivePower", "onGridPower"],
         "power",
     ),
-    "batteryVoltage": (["batteryVoltage", "batteryTerminalVoltage"], None),
-    "batteryChargingCurrent": (
-        ["batteryChargingCurrent", "batteryChargeCurrent"],
-        None,
-    ),
-    "batteryDischargeCurrent": (
-        ["batteryDischargeCurrent", "batteryDischargingCurrent"],
-        None,
-    ),
-    "batterySOC": (
-        ["batterySOC", "batteryCapacity", "batteryPercentage", "soc"],
-        None,
-    ),
+    "batteryVoltage": (["batteryVoltage"], None),
+    "batteryChargingCurrent": (["batteryChargingCurrent"], None),
+    "batteryDischargeCurrent": (["batteryDischargeCurrent"], None),
+    # No batterySOC on PI30 — it publishes batteryCapacity / batteryPercentage.
+    "batterySOC": (["batterySOC", "batteryCapacity", "batteryPercentage"], None),
 }
 
 # ─── Control option maps ───────────────────────────────────────────────────────
-# Output Source Priority (outputSourcePrioritySetting): 0=USO, 1=SUB, 2=SBU.
+# Output Source Priority.  Read from the state field `outputSourcePriority`,
+# written as `settingDeviceOutputSourcePriority`; both use the PI30 POP codes.
 OUTPUT_PRIORITY_BY_VALUE: dict[int, str] = {
     0: "Utility First (USO)",
     1: "Solar First (SUB)",
@@ -171,42 +153,159 @@ OUTPUT_PRIORITY_BY_VALUE: dict[int, str] = {
 OUTPUT_PRIORITY_OPTIONS: list[str] = list(OUTPUT_PRIORITY_BY_VALUE.values())
 
 # Alias table for resolving a text value/valueDisplay onto an option.  Keys are
-# normalised (lowercase, non-alphanumerics collapsed to single spaces).
+# normalised (lowercase, non-alphanumerics collapsed to single spaces).  The
+# "->" strings are the live labels the portal returns.
 OUTPUT_PRIORITY_ALIASES: dict[str, str] = {
     "uso": OUTPUT_PRIORITY_BY_VALUE[0],
+    "usb": OUTPUT_PRIORITY_BY_VALUE[0],
     "utility": OUTPUT_PRIORITY_BY_VALUE[0],
     "utility first": OUTPUT_PRIORITY_BY_VALUE[0],
-    "utility priority": OUTPUT_PRIORITY_BY_VALUE[0],
-    "grid first": OUTPUT_PRIORITY_BY_VALUE[0],
+    "utilitysolarbat": OUTPUT_PRIORITY_BY_VALUE[0],
+    "mains power photovoltaic battery": OUTPUT_PRIORITY_BY_VALUE[0],
     "sub": OUTPUT_PRIORITY_BY_VALUE[1],
     "solar first": OUTPUT_PRIORITY_BY_VALUE[1],
-    "solar priority": OUTPUT_PRIORITY_BY_VALUE[1],
-    "solar utility battery": OUTPUT_PRIORITY_BY_VALUE[1],
+    "solarutilitybat": OUTPUT_PRIORITY_BY_VALUE[1],
+    "photovoltaic mains power battery": OUTPUT_PRIORITY_BY_VALUE[1],
     "sbu": OUTPUT_PRIORITY_BY_VALUE[2],
     "battery first": OUTPUT_PRIORITY_BY_VALUE[2],
+    "solarbatutility": OUTPUT_PRIORITY_BY_VALUE[2],
     "solar battery first": OUTPUT_PRIORITY_BY_VALUE[2],
-    "solar battery utility": OUTPUT_PRIORITY_BY_VALUE[2],
+    "photovoltaic battery mains power": OUTPUT_PRIORITY_BY_VALUE[2],
 }
 
-# Charger Source Priority (chargerSourcePrioritySetting): 0=CSO, 1=SNU, 2=OSO.
+# Charger Source Priority.  Read from the state field `chargerSourcePriority`,
+# written as `settingDeviceChargerPriority`.  These are the PI30 PCP codes —
+# **four** of them, not three.  Releases before 2.6.0 mapped 0/1/2 onto
+# CSO/SNU/OSO, which does not match what the device reports or accepts.
 CHARGER_PRIORITY_BY_VALUE: dict[int, str] = {
-    0: "Solar + Utility (CSO)",
-    1: "Solar First (SNU)",
-    2: "Solar Only (OSO)",
+    0: "Utility First",
+    1: "Solar First",
+    2: "Solar + Utility",
+    3: "Solar Only",
 }
 CHARGER_PRIORITY_OPTIONS: list[str] = list(CHARGER_PRIORITY_BY_VALUE.values())
 
 CHARGER_PRIORITY_ALIASES: dict[str, str] = {
-    "cso": CHARGER_PRIORITY_BY_VALUE[0],
-    "solar utility": CHARGER_PRIORITY_BY_VALUE[0],
-    "solar and utility": CHARGER_PRIORITY_BY_VALUE[0],
     "utility first": CHARGER_PRIORITY_BY_VALUE[0],
-    "snu": CHARGER_PRIORITY_BY_VALUE[1],
+    "for utility first": CHARGER_PRIORITY_BY_VALUE[0],
+    "utility": CHARGER_PRIORITY_BY_VALUE[0],
     "solar first": CHARGER_PRIORITY_BY_VALUE[1],
-    "solar priority": CHARGER_PRIORITY_BY_VALUE[1],
-    "oso": CHARGER_PRIORITY_BY_VALUE[2],
-    "solar only": CHARGER_PRIORITY_BY_VALUE[2],
-    "only solar": CHARGER_PRIORITY_BY_VALUE[2],
+    "for solar first": CHARGER_PRIORITY_BY_VALUE[1],
+    "snu": CHARGER_PRIORITY_BY_VALUE[1],
+    "solar utility": CHARGER_PRIORITY_BY_VALUE[2],
+    "solar and utility": CHARGER_PRIORITY_BY_VALUE[2],
+    "for solar and utility charging": CHARGER_PRIORITY_BY_VALUE[2],
+    "cso": CHARGER_PRIORITY_BY_VALUE[2],
+    "solar only": CHARGER_PRIORITY_BY_VALUE[3],
+    "only solar": CHARGER_PRIORITY_BY_VALUE[3],
+    "only solar permitted": CHARGER_PRIORITY_BY_VALUE[3],
+    "for only solar charging": CHARGER_PRIORITY_BY_VALUE[3],
+    "oso": CHARGER_PRIORITY_BY_VALUE[3],
+}
+
+# ─── Boolean controls ──────────────────────────────────────────────────────────
+# Switches that map onto a single enable/disable setting.  `on_value` /
+# `off_value` are what the write endpoint expects (strings — the portal sends
+# enum values quoted); `on_codes` are the state-snapshot codes that mean "on".
+BOOLEAN_CONTROLS: dict[str, dict] = {
+    "gridFeedIn": {
+        "name": "Solar Feed to Grid",
+        "icon": "mdi:transmission-tower-export",
+        "on_value": "1",
+        "off_value": "0",
+        "on_codes": {1},
+    },
+    "buzzer": {
+        "name": "Buzzer",
+        "icon": "mdi:volume-high",
+        "on_value": "1",
+        "off_value": "0",
+        "on_codes": {1},
+    },
+    "overloadBypass": {
+        "name": "Overload Bypass",
+        "icon": "mdi:transmission-tower",
+        "on_value": "1",
+        "off_value": "0",
+        "on_codes": {1},
+    },
+    "overLoadRestart": {
+        "name": "Overload Restart",
+        "icon": "mdi:restart",
+        "on_value": "1",
+        "off_value": "0",
+        "on_codes": {1},
+    },
+    "overTemperatureRestart": {
+        "name": "Over-temperature Restart",
+        "icon": "mdi:restart-alert",
+        "on_value": "1",
+        "off_value": "0",
+        "on_codes": {1},
+    },
+    "lcdBacklight": {
+        "name": "LCD Backlight",
+        "icon": "mdi:monitor",
+        "on_value": "1",
+        "off_value": "0",
+        "on_codes": {1},
+    },
+    "lcdReturnToDefaultPage": {
+        "name": "LCD Return to Default Page",
+        "icon": "mdi:monitor-arrow-down",
+        "on_value": "1",
+        "off_value": "0",
+        "on_codes": {1},
+    },
+    "faultCodeRecord": {
+        "name": "Fault Code Recording",
+        "icon": "mdi:clipboard-alert",
+        "on_value": "1",
+        "off_value": "0",
+        "on_codes": {1},
+    },
+    "alarmOnPrimarySourceInterrupt": {
+        "name": "Alarm on Primary Source Interrupt",
+        "icon": "mdi:bell-alert",
+        "on_value": "1",
+        "off_value": "0",
+        "on_codes": {1},
+    },
+}
+
+# ─── Numeric controls ──────────────────────────────────────────────────────────
+# Writable numbers, with the ranges the portal's own inputs enforce.  The
+# battery charge/discharge/grid-charge limits shipped before 2.6.0 are gone:
+# no such keys exist on PI30/VMIII, so those entities could never read or write.
+NUMBER_CONTROLS: dict[str, dict] = {
+    "equalizationVoltage": {
+        "name": "Battery Equalization Voltage",
+        "icon": "mdi:battery-heart-variant",
+        "min": 20.0,
+        "max": 60.0,
+        "step": 0.1,
+        "unit": "V",
+        "device_class": "voltage",
+        "numeric": True,
+    },
+    "equalizationPeriod": {
+        "name": "Battery Equalization Period",
+        "icon": "mdi:calendar-sync",
+        "min": 0,
+        "max": 99,
+        "step": 1,
+        "unit": "d",
+        "numeric": True,
+    },
+    "equalizationOverTime": {
+        "name": "Battery Equalization Timeout",
+        "icon": "mdi:timer-sand",
+        "min": 0,
+        "max": 900,
+        "step": 5,
+        "unit": "min",
+        "numeric": True,
+    },
 }
 
 # ─── Sensor keys ───────────────────────────────────────────────────────────────

--- a/custom_components/solar_of_things/diagnostics.py
+++ b/custom_components/solar_of_things/diagnostics.py
@@ -1,0 +1,148 @@
+"""Diagnostics support for Solar of Things.
+
+Settings → Devices & Services → Solar of Things → ⋮ → *Download diagnostics*
+produces a JSON file containing the raw payloads the integration received from
+the portal, with credentials and tokens removed.
+
+That file is the fastest way to work out why an entity reads ``unknown``: it
+lists every attribute name the device actually publishes, alongside the names
+the integration looked for.  Attach it to a GitHub issue and the missing name
+can be added to the candidate lists in ``const.py``.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    CHARGER_PRIORITY_ALIASES,
+    CHARGER_PRIORITY_BY_VALUE,
+    DOMAIN,
+    OUTPUT_PRIORITY_ALIASES,
+    OUTPUT_PRIORITY_BY_VALUE,
+    SETTING_KEY_CANDIDATES,
+    STATE_KEY_CANDIDATES,
+    TELEMETRY_STATE_FALLBACKS,
+)
+from .helpers import (
+    entry_display,
+    entry_value,
+    find_entry,
+    resolve_option,
+    state_fields,
+)
+
+TO_REDACT = {
+    "password",
+    "iot_token",
+    "refresh_token",
+    "user_id",
+    "account",
+    "access_token",
+    "accessToken",
+    "refreshToken",
+}
+
+
+def _priority_report(
+    settings: dict[str, Any],
+    fields: dict[str, Any],
+    control: str,
+    by_value: dict[int, str],
+    aliases: dict[str, str],
+) -> dict[str, Any]:
+    """Show what each source returned for a priority control and how it resolved."""
+    report: dict[str, Any] = {
+        "searched_state_keys": STATE_KEY_CANDIDATES[control],
+        "searched_setting_keys": SETTING_KEY_CANDIDATES[control],
+    }
+
+    for source, haystack, candidates in (
+        ("state", fields, STATE_KEY_CANDIDATES[control]),
+        ("settings", settings, SETTING_KEY_CANDIDATES[control]),
+    ):
+        key, entry = find_entry(haystack, candidates)
+        raw, display = entry_value(entry), entry_display(entry)
+        report[source] = {
+            "matched_key": key,
+            "raw_value": raw,
+            "raw_display": display,
+            "resolved_option": (
+                resolve_option(raw, display, by_value, aliases) if key else None
+            ),
+        }
+
+    return report
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    stored = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
+    station_coordinator = stored.get("station_coordinator")
+    device_coordinators: dict[str, Any] = stored.get("device_coordinators", {})
+
+    devices: list[dict[str, Any]] = []
+    for device_id, coordinator in device_coordinators.items():
+        data = coordinator.data or {}
+        settings = data.get("settings") or {}
+        state = data.get("state") or {}
+        fields = state_fields(state)
+        time_series = data.get("time_series") or {}
+
+        devices.append(
+            {
+                "device_id": device_id,
+                "device_meta": data.get("device_meta"),
+                # Key lists first: this is usually all that is needed to spot a
+                # measurement published under an unexpected name.
+                "time_series_keys": sorted(time_series),
+                "settings_keys": sorted(settings),
+                "state_field_keys": sorted(fields),
+                "time_series_values": time_series,
+                "settings": settings,
+                "state_fields": fields,
+                "firing_alarms": state.get("firingAlarms"),
+                "resolution": {
+                    "output_source_priority": _priority_report(
+                        settings, fields, "outputSourcePriority",
+                        OUTPUT_PRIORITY_BY_VALUE, OUTPUT_PRIORITY_ALIASES,
+                    ),
+                    "charger_source_priority": _priority_report(
+                        settings, fields, "chargerSourcePriority",
+                        CHARGER_PRIORITY_BY_VALUE, CHARGER_PRIORITY_ALIASES,
+                    ),
+                    "telemetry_fallbacks": {
+                        key: {
+                            "value": time_series.get(key),
+                            "searched_state_keys": candidates,
+                            "matched_state_key": find_entry(fields, candidates)[0],
+                        }
+                        for key, (candidates, _kind) in TELEMETRY_STATE_FALLBACKS.items()
+                    },
+                },
+            }
+        )
+
+    return async_redact_data(
+        {
+            "entry": {
+                "version": entry.version,
+                "data": dict(entry.data),
+                "options": dict(entry.options),
+            },
+            "station": {
+                "station_id": stored.get("station_id"),
+                "monthly": (station_coordinator.data or {}).get("monthly")
+                if station_coordinator
+                else None,
+                "device_count": len(device_coordinators),
+            },
+            "devices": devices,
+        },
+        TO_REDACT,
+    )

--- a/custom_components/solar_of_things/helpers.py
+++ b/custom_components/solar_of_things/helpers.py
@@ -1,0 +1,246 @@
+"""Value-resolution helpers for the Siseli API payloads.
+
+The portal exposes device data through three differently-shaped payloads, and
+the attribute names inside them vary between inverter models (PI30, VMIII,
+Voltronic clones, …).  Everything in this module therefore looks a value up by
+a *list of candidate keys*, matched case-insensitively, instead of hard-coding
+one name.
+
+  settings   ``POST /apis/remote/device/configs/cache/get``
+             ``{"outputSourcePrioritySetting": {"key": …, "value": 2,
+                                                "valueDisplay": "SBU"}, …}``
+             This is a *write cache*: it holds the values that were pushed to
+             the device through the portal, so on an account that has never
+             changed a setting remotely it comes back empty.  That is why the
+             priority selects showed ``unknown`` — there was nothing to read.
+
+  state      ``GET /apis/deviceState/simple/state/latest/v1``
+             ``{"fields": {"outputSourcePriority": {"value": 2,
+                                                    "valueDisplay": "SBU",
+                                                    "unit": "W"}, …},
+                "firingAlarms": [...]}``
+             The live snapshot the portal's overview page renders.  This is the
+             authoritative source for *current* values and is what we read
+             first everywhere.
+
+  timeseries ``POST /apis/deviceState/simple/attribute/keys/history/v1``
+             ``{"payload": {"fields": {"pvInputPower": [...], …}}}``
+             Only returns keys that were explicitly requested *and* that the
+             model actually records, so a key missing here does not mean the
+             device lacks the measurement — the state snapshot may still have
+             it under a different name.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Iterable
+
+_LOGGER = logging.getLogger(__name__)
+
+# Where a field entry keeps its unit, depending on model/firmware.
+_UNIT_KEYS = ("unit", "unitSymbol", "valueUnit", "units")
+
+# Scale factors onto the canonical unit used by the integration.
+_POWER_SCALE = {"w": 1.0, "kw": 1000.0, "mw": 1_000_000.0, "va": 1.0, "kva": 1000.0}
+_ENERGY_SCALE = {"wh": 0.001, "kwh": 1.0, "mwh": 1000.0}
+
+# kind → (canonical unit, scale table).  Kinds without a table are passed
+# through unscaled.
+_SCALES: dict[str, dict[str, float]] = {
+    "power": _POWER_SCALE,
+    "energy": _ENERGY_SCALE,
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Generic extraction
+# ──────────────────────────────────────────────────────────────────────────────
+
+def state_fields(state: dict[str, Any] | None) -> dict[str, Any]:
+    """Return the ``fields`` mapping of a state/latest payload.
+
+    Accepts the payload either already unwrapped (``{"fields": {...}}``) or
+    wrapped one level deeper (``{"data": {"fields": {...}}}``), and tolerates
+    a payload that *is* the fields mapping itself.
+    """
+    if not isinstance(state, dict):
+        return {}
+    for candidate in (state, state.get("data")):
+        if isinstance(candidate, dict):
+            fields = candidate.get("fields")
+            if isinstance(fields, dict):
+                return fields
+    # Some firmwares return the attributes flat; treat dict-of-dicts as fields.
+    if state and all(isinstance(v, dict) for v in state.values()):
+        return state
+    return {}
+
+
+def find_entry(
+    fields: dict[str, Any] | None, candidates: Iterable[str]
+) -> tuple[str | None, Any]:
+    """Return ``(matched_key, entry)`` for the first candidate present.
+
+    Matching is case-insensitive because the API is inconsistent about the
+    leading character (``PV1InputVoltage`` vs ``pv1InputCurrent``).
+    """
+    if not isinstance(fields, dict) or not fields:
+        return None, None
+    lowered = {str(k).lower(): k for k in fields}
+    for candidate in candidates:
+        actual = lowered.get(str(candidate).lower())
+        if actual is not None:
+            return actual, fields[actual]
+    return None, None
+
+
+def entry_value(entry: Any) -> Any:
+    """Return the raw value of a field/setting entry (or the entry itself)."""
+    if isinstance(entry, dict):
+        for key in ("value", "val", "rawValue"):
+            if key in entry:
+                return entry[key]
+        return None
+    return entry
+
+
+def entry_display(entry: Any) -> Any:
+    """Return the human-readable rendering of a field/setting entry, if any."""
+    if isinstance(entry, dict):
+        for key in ("valueDisplay", "displayValue", "display", "text"):
+            value = entry.get(key)
+            if value not in (None, ""):
+                return value
+    return None
+
+
+def entry_unit(entry: Any) -> str | None:
+    """Return the unit string attached to a field entry, if any."""
+    if isinstance(entry, dict):
+        for key in _UNIT_KEYS:
+            unit = entry.get(key)
+            if isinstance(unit, str) and unit.strip():
+                return unit.strip()
+    return None
+
+
+def to_float(value: Any) -> float | None:
+    """Best-effort float conversion; returns None for blanks and non-numerics."""
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        # Values sometimes arrive with the unit appended, e.g. "1234.5 W".
+        match = re.match(r"^[-+]?\d*\.?\d+", text)
+        if not match:
+            return None
+        try:
+            return float(match.group(0))
+        except ValueError:
+            return None
+
+
+def scale_value(value: float, unit: str | None, kind: str | None) -> float:
+    """Convert *value* to the integration's canonical unit for *kind*.
+
+    Unknown units and unknown kinds are passed through untouched — better a
+    plausible number in the wrong unit than no reading at all.
+    """
+    table = _SCALES.get(kind or "")
+    if not table or not unit:
+        return value
+    factor = table.get(unit.strip().lower())
+    if factor is None:
+        return value
+    return value * factor
+
+
+def state_number(
+    fields: dict[str, Any] | None,
+    candidates: Iterable[str],
+    kind: str | None = None,
+) -> float | None:
+    """Read a numeric measurement out of the state snapshot.
+
+    Returns None when no candidate key exists or the value is not numeric.
+    """
+    key, entry = find_entry(fields, candidates)
+    if key is None:
+        return None
+    number = to_float(entry_value(entry))
+    if number is None:
+        return None
+    return scale_value(number, entry_unit(entry), kind)
+
+
+def setting_number(
+    settings: dict[str, Any] | None, candidates: Iterable[str]
+) -> float | None:
+    """Read a numeric value out of the remote-config settings cache."""
+    _key, entry = find_entry(settings, candidates)
+    if entry is None:
+        return None
+    return to_float(entry_value(entry))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Enum / option resolution
+# ──────────────────────────────────────────────────────────────────────────────
+
+def normalise_text(value: Any) -> str:
+    """Lowercase *value* and collapse every non-alphanumeric run to one space."""
+    if value is None:
+        return ""
+    return re.sub(r"[^a-z0-9]+", " ", str(value).lower()).strip()
+
+
+def _option_from_number(raw: Any, by_value: dict[int, str]) -> str | None:
+    number = to_float(raw)
+    if number is None or number != int(number):
+        return None
+    return by_value.get(int(number))
+
+
+def _option_from_text(raw: Any, aliases: dict[str, str]) -> str | None:
+    text = normalise_text(raw)
+    if not text:
+        return None
+    if text in aliases:
+        return aliases[text]
+    # Fall back to scanning for a mode abbreviation (SBU, SNU, …) anywhere in
+    # the string, so localised labels like "Solar first (SBU)" still resolve.
+    for token in text.split():
+        if len(token) == 3 and token in aliases:
+            return aliases[token]
+    return None
+
+
+def resolve_option(
+    raw: Any,
+    display: Any,
+    by_value: dict[int, str],
+    aliases: dict[str, str],
+) -> str | None:
+    """Map an API value/display pair onto one of the select's option strings.
+
+    Handles all the shapes seen in the wild: an integer code (``2``), a numeric
+    string (``"2"``), an abbreviation (``"SBU"``) and a full label
+    (``"Solar+Battery first (SBU)"``).  Returns None when nothing matches so the
+    caller can log the raw payload instead of crashing the select entity.
+    """
+    for candidate in (raw, display):
+        option = _option_from_number(candidate, by_value)
+        if option is not None:
+            return option
+    for candidate in (display, raw):
+        option = _option_from_text(candidate, aliases)
+        if option is not None:
+            return option
+    return None

--- a/custom_components/solar_of_things/manifest.json
+++ b/custom_components/solar_of_things/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "pycryptodome>=3.9.0"
   ],
-  "version": "2.4.3"
+  "version": "2.4.4"
 }

--- a/custom_components/solar_of_things/manifest.json
+++ b/custom_components/solar_of_things/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "pycryptodome>=3.9.0"
   ],
-  "version": "2.4.2"
+  "version": "2.4.3"
 }

--- a/custom_components/solar_of_things/manifest.json
+++ b/custom_components/solar_of_things/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "pycryptodome>=3.9.0"
   ],
-  "version": "2.4.4"
+  "version": "2.4.5"
 }

--- a/custom_components/solar_of_things/manifest.json
+++ b/custom_components/solar_of_things/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "pycryptodome>=3.9.0"
   ],
-  "version": "2.5.0"
+  "version": "2.6.0"
 }

--- a/custom_components/solar_of_things/manifest.json
+++ b/custom_components/solar_of_things/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "pycryptodome>=3.9.0"
   ],
-  "version": "2.4.5"
+  "version": "2.5.0"
 }

--- a/custom_components/solar_of_things/number.py
+++ b/custom_components/solar_of_things/number.py
@@ -10,9 +10,32 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, SETTING_KEY_CANDIDATES, STATE_KEY_CANDIDATES
+from .helpers import entry_value, find_entry, state_fields, to_float
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _limit_value(coordinator_data: dict | None, control: str) -> float | None:
+    """Return the numeric value of a limit setting, snapshot before cache.
+
+    The settings cache stores each key as ``{"key": …, "value": …}``; reading
+    the entry itself (as this platform used to) hands Home Assistant a dict and
+    the number shows as unavailable.
+    """
+    data = coordinator_data or {}
+
+    for fields, candidates in (
+        (state_fields(data.get("state")), STATE_KEY_CANDIDATES.get(control, [control])),
+        (data.get("settings") or {}, SETTING_KEY_CANDIDATES.get(control, [control])),
+    ):
+        _key, entry = find_entry(fields, candidates)
+        if entry is None:
+            continue
+        number = to_float(entry_value(entry))
+        if number is not None:
+            return number
+    return None
 
 
 async def async_setup_entry(
@@ -77,7 +100,7 @@ class SolarOfThingsBatteryChargeLimitNumber(_BaseNumber):
 
     @property
     def native_value(self):
-        return ((self.coordinator.data or {}).get("settings") or {}).get(self._setting_key)
+        return _limit_value(self.coordinator.data, self._setting_key)
 
     async def async_set_native_value(self, value: float) -> None:
         await self.hass.async_add_executor_job(self._api.set_battery_charge_limit, self._device_id, int(value))
@@ -100,7 +123,7 @@ class SolarOfThingsBatteryDischargeLimitNumber(_BaseNumber):
 
     @property
     def native_value(self):
-        return ((self.coordinator.data or {}).get("settings") or {}).get(self._setting_key)
+        return _limit_value(self.coordinator.data, self._setting_key)
 
     async def async_set_native_value(self, value: float) -> None:
         await self.hass.async_add_executor_job(self._api.set_battery_discharge_limit, self._device_id, int(value))
@@ -124,7 +147,7 @@ class SolarOfThingsGridChargeLimitNumber(_BaseNumber):
 
     @property
     def native_value(self):
-        return ((self.coordinator.data or {}).get("settings") or {}).get(self._setting_key)
+        return _limit_value(self.coordinator.data, self._setting_key)
 
     async def async_set_native_value(self, value: float) -> None:
         await self.hass.async_add_executor_job(self._api.set_grid_charge_limit, self._device_id, int(value))

--- a/custom_components/solar_of_things/number.py
+++ b/custom_components/solar_of_things/number.py
@@ -1,35 +1,47 @@
-"""Number platform for Solar of Things integration."""
+"""Number platform for Solar of Things integration.
+
+The entities here are driven by ``NUMBER_CONTROLS`` — the numeric settings the
+portal's control panel can actually write.  The battery charge limit, battery
+discharge limit and grid charge limit shipped before 2.6.0 are gone: PI30/VMIII
+publishes no such attributes and the write endpoint has no keys for them, so
+those sliders read as unavailable and their writes went nowhere.
+"""
 from __future__ import annotations
 
 import logging
 
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, SETTING_KEY_CANDIDATES, STATE_KEY_CANDIDATES
+from .const import DOMAIN, NUMBER_CONTROLS, SETTING_KEY_CANDIDATES, STATE_KEY_CANDIDATES
 from .helpers import entry_value, find_entry, state_fields, to_float
 
 _LOGGER = logging.getLogger(__name__)
 
+_DEVICE_CLASSES = {
+    "voltage": NumberDeviceClass.VOLTAGE,
+    "current": NumberDeviceClass.CURRENT,
+    "power": NumberDeviceClass.POWER,
+}
 
-def _limit_value(coordinator_data: dict | None, control: str) -> float | None:
-    """Return the numeric value of a limit setting, snapshot before cache.
 
-    The settings cache stores each key as ``{"key": …, "value": …}``; reading
+def _control_value(coordinator_data: dict | None, control: str) -> float | None:
+    """Return the numeric value of a control, snapshot before config cache.
+
+    The settings cache stores each key as ``{"key": …, "value": …}``; returning
     the entry itself (as this platform used to) hands Home Assistant a dict and
     the number shows as unavailable.
     """
     data = coordinator_data or {}
 
-    for fields, candidates in (
+    for haystack, candidates in (
         (state_fields(data.get("state")), STATE_KEY_CANDIDATES.get(control, [control])),
         (data.get("settings") or {}, SETTING_KEY_CANDIDATES.get(control, [control])),
     ):
-        _key, entry = find_entry(fields, candidates)
+        _key, entry = find_entry(haystack, candidates)
         if entry is None:
             continue
         number = to_float(entry_value(entry))
@@ -50,28 +62,43 @@ async def async_setup_entry(
     station_id: str = data["station_id"]
     device_coordinators = data["device_coordinators"]
 
-    entities: list[NumberEntity] = []
-
-    for device_id, coordinator in device_coordinators.items():
-        device_name = (coordinator.device_meta or {}).get("name") or device_id
-        entities.extend(
-            [
-                SolarOfThingsBatteryChargeLimitNumber(api, coordinator, station_id, device_id, device_name),
-                SolarOfThingsBatteryDischargeLimitNumber(api, coordinator, station_id, device_id, device_name),
-                SolarOfThingsGridChargeLimitNumber(api, coordinator, station_id, device_id, device_name),
-            ]
+    entities: list[NumberEntity] = [
+        SolarOfThingsControlNumber(
+            api, coordinator, station_id, device_id,
+            (coordinator.device_meta or {}).get("name") or device_id,
+            control, spec,
         )
+        for device_id, coordinator in device_coordinators.items()
+        for control, spec in NUMBER_CONTROLS.items()
+    ]
 
     async_add_entities(entities)
 
 
-class _BaseNumber(CoordinatorEntity, NumberEntity):
-    def __init__(self, api, coordinator, station_id: str, device_id: str, device_name: str) -> None:
+class SolarOfThingsControlNumber(CoordinatorEntity, NumberEntity):
+    """Writable numeric device setting."""
+
+    def __init__(
+        self, api, coordinator, station_id: str, device_id: str, device_name: str,
+        control: str, spec: dict,
+    ) -> None:
         super().__init__(coordinator)
         self._api = api
         self._station_id = station_id
         self._device_id = device_id
         self._device_name = device_name
+        self._control = control
+
+        self._attr_has_entity_name = True
+        self._attr_name = spec["name"]
+        self._attr_unique_id = f"{DOMAIN}_{station_id}_{device_id}_{control}"
+        self._attr_icon = spec.get("icon")
+        self._attr_native_min_value = spec["min"]
+        self._attr_native_max_value = spec["max"]
+        self._attr_native_step = spec["step"]
+        self._attr_native_unit_of_measurement = spec.get("unit")
+        self._attr_device_class = _DEVICE_CLASSES.get(spec.get("device_class"))
+        self._attr_mode = NumberMode.BOX
 
     @property
     def device_info(self):
@@ -83,72 +110,12 @@ class _BaseNumber(CoordinatorEntity, NumberEntity):
             "via_device": (DOMAIN, self._station_id),
         }
 
-
-class SolarOfThingsBatteryChargeLimitNumber(_BaseNumber):
-    _setting_key = "batteryChargeLimit"
-
-    def __init__(self, api, coordinator, station_id: str, device_id: str, device_name: str) -> None:
-        super().__init__(api, coordinator, station_id, device_id, device_name)
-        self._attr_name = f"{device_name} Battery Charge Limit"
-        self._attr_unique_id = f"{DOMAIN}_{station_id}_{device_id}_battery_charge_limit"
-        self._attr_native_min_value = 0
-        self._attr_native_max_value = 100
-        self._attr_native_step = 1
-        self._attr_native_unit_of_measurement = PERCENTAGE
-        self._attr_mode = NumberMode.SLIDER
-        self._attr_icon = "mdi:battery-arrow-up"
-
     @property
     def native_value(self):
-        return _limit_value(self.coordinator.data, self._setting_key)
+        return _control_value(self.coordinator.data, self._control)
 
     async def async_set_native_value(self, value: float) -> None:
-        await self.hass.async_add_executor_job(self._api.set_battery_charge_limit, self._device_id, int(value))
-        await self.coordinator.async_request_refresh()
-
-
-class SolarOfThingsBatteryDischargeLimitNumber(_BaseNumber):
-    _setting_key = "batteryDischargeLimit"
-
-    def __init__(self, api, coordinator, station_id: str, device_id: str, device_name: str) -> None:
-        super().__init__(api, coordinator, station_id, device_id, device_name)
-        self._attr_name = f"{device_name} Battery Discharge Limit"
-        self._attr_unique_id = f"{DOMAIN}_{station_id}_{device_id}_battery_discharge_limit"
-        self._attr_native_min_value = 0
-        self._attr_native_max_value = 100
-        self._attr_native_step = 1
-        self._attr_native_unit_of_measurement = PERCENTAGE
-        self._attr_mode = NumberMode.SLIDER
-        self._attr_icon = "mdi:battery-arrow-down"
-
-    @property
-    def native_value(self):
-        return _limit_value(self.coordinator.data, self._setting_key)
-
-    async def async_set_native_value(self, value: float) -> None:
-        await self.hass.async_add_executor_job(self._api.set_battery_discharge_limit, self._device_id, int(value))
-        await self.coordinator.async_request_refresh()
-
-
-class SolarOfThingsGridChargeLimitNumber(_BaseNumber):
-    _setting_key = "gridChargeLimit"
-
-    def __init__(self, api, coordinator, station_id: str, device_id: str, device_name: str) -> None:
-        super().__init__(api, coordinator, station_id, device_id, device_name)
-        self._attr_name = f"{device_name} Grid Charge Limit"
-        self._attr_unique_id = f"{DOMAIN}_{station_id}_{device_id}_grid_charge_limit"
-        self._attr_native_min_value = 0
-        self._attr_native_max_value = 5000
-        self._attr_native_step = 100
-        self._attr_native_unit_of_measurement = "W"
-        self._attr_mode = NumberMode.SLIDER
-        self._attr_device_class = NumberDeviceClass.POWER
-        self._attr_icon = "mdi:transmission-tower-import"
-
-    @property
-    def native_value(self):
-        return _limit_value(self.coordinator.data, self._setting_key)
-
-    async def async_set_native_value(self, value: float) -> None:
-        await self.hass.async_add_executor_job(self._api.set_grid_charge_limit, self._device_id, int(value))
+        await self.hass.async_add_executor_job(
+            self._api.set_number_control, self._device_id, self._control, value
+        )
         await self.coordinator.async_request_refresh()

--- a/custom_components/solar_of_things/select.py
+++ b/custom_components/solar_of_things/select.py
@@ -1,7 +1,21 @@
-"""Select platform for Solar of Things integration."""
+"""Select platform for Solar of Things integration.
+
+Read-back strategy
+──────────────────
+Both priority selects used to read only the remote-config *settings cache*
+(``/apis/remote/device/configs/cache/get``).  That cache only contains keys
+that have previously been written through the portal, so on most accounts it
+comes back empty and the selects showed ``unknown``.
+
+They now resolve their current option from the live state snapshot
+(``/apis/deviceState/simple/state/latest/v1``) first and fall back to the
+settings cache, and they accept every value shape the API uses: an integer
+code, a numeric string, an abbreviation (``"SBU"``) or a full label.
+"""
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
@@ -9,31 +23,31 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import (
+    CHARGER_PRIORITY_ALIASES,
+    CHARGER_PRIORITY_BY_VALUE,
+    CHARGER_PRIORITY_OPTIONS,
+    DOMAIN,
+    OUTPUT_PRIORITY_ALIASES,
+    OUTPUT_PRIORITY_BY_VALUE,
+    OUTPUT_PRIORITY_OPTIONS,
+    SETTING_KEY_CANDIDATES,
+    STATE_KEY_CANDIDATES,
+)
+from .helpers import (
+    entry_display,
+    entry_value,
+    find_entry,
+    resolve_option,
+    state_fields,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
-# Real API key: outputSourcePrioritySetting  (integer value)
-# 0 = USO  Utility first
-# 1 = SUB  Solar first (grid supplement)
-# 2 = SBU  Solar + Battery first (grid only last resort)
-OUTPUT_MODE_BY_VALUE: dict[int, str] = {
-    0: "Utility First (USO)",
-    1: "Solar First (SUB)",
-    2: "Solar+Battery First (SBU)",
-}
-OUTPUT_MODES = list(OUTPUT_MODE_BY_VALUE.values())
-
-# Real API key: chargerSourcePrioritySetting  (integer value)
-# 0 = CSO  Solar + Utility charging (utility has priority)
-# 1 = SNU  Solar First for charging, utility as fallback
-# 2 = OSO  Solar Only charging
-CHARGER_PRIORITY_BY_VALUE: dict[int, str] = {
-    0: "Solar + Utility (CSO)",
-    1: "Solar First (SNU)",
-    2: "Solar Only (OSO)",
-}
-CHARGER_PRIORITIES = list(CHARGER_PRIORITY_BY_VALUE.values())
+# Re-exported under their previous names for backwards compatibility.
+OUTPUT_MODE_BY_VALUE = OUTPUT_PRIORITY_BY_VALUE
+OUTPUT_MODES = OUTPUT_PRIORITY_OPTIONS
+CHARGER_PRIORITIES = CHARGER_PRIORITY_OPTIONS
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
@@ -56,13 +70,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     async_add_entities(entities)
 
 
-class _BaseSelect(CoordinatorEntity, SelectEntity):
+class _BasePrioritySelect(CoordinatorEntity, SelectEntity):
+    """Select backed by a device priority setting.
+
+    Subclasses provide the candidate key names and the value/alias tables; the
+    resolution order (state snapshot → settings cache) is shared.
+    """
+
+    _state_candidates: list[str] = []
+    _setting_candidates: list[str] = []
+    _by_value: dict[int, str] = {}
+    _aliases: dict[str, str] = {}
+
     def __init__(self, api, coordinator, station_id: str, device_id: str, device_name: str) -> None:
         super().__init__(coordinator)
         self._api = api
         self._station_id = station_id
         self._device_id = device_id
         self._device_name = device_name
+        self._unresolved_logged: str | None = None
 
     @property
     def device_info(self):
@@ -74,61 +100,104 @@ class _BaseSelect(CoordinatorEntity, SelectEntity):
             "via_device": (DOMAIN, self._station_id),
         }
 
+    def _read_source(self) -> tuple[str | None, str | None, Any, Any]:
+        """Return ``(source, matched_key, raw_value, display_value)``.
 
-class SolarOfThingsOperatingModeSelect(_BaseSelect):
-    """Select entity for Output Source Priority (outputSourcePrioritySetting).
+        Prefers the live state snapshot, because the settings cache only holds
+        values previously written through the portal and is empty on accounts
+        that have never used remote control.
+        """
+        data = self.coordinator.data or {}
 
-    Reflects the real device API key.  Values 0/1/2 map to USO/SUB/SBU.
+        key, entry = find_entry(state_fields(data.get("state")), self._state_candidates)
+        if key is not None:
+            raw, display = entry_value(entry), entry_display(entry)
+            if raw not in (None, "") or display not in (None, ""):
+                return "state", key, raw, display
+
+        key, entry = find_entry(data.get("settings") or {}, self._setting_candidates)
+        if key is not None:
+            return "settings", key, entry_value(entry), entry_display(entry)
+
+        return None, None, None, None
+
+    @property
+    def current_option(self) -> str | None:
+        source, key, raw, display = self._read_source()
+        if source is None:
+            return None
+
+        option = resolve_option(raw, display, self._by_value, self._aliases)
+        if option is None:
+            # Log once per distinct unrecognised value rather than on every
+            # poll, so an unknown model shows up in the log without spamming it.
+            signature = f"{key}={raw!r}/{display!r}"
+            if self._unresolved_logged != signature:
+                self._unresolved_logged = signature
+                _LOGGER.warning(
+                    "SolarOfThings %s: could not map %s value %r (display %r) from the "
+                    "%s payload onto a known option %s. Please report this via a GitHub "
+                    "issue so the mapping can be added.",
+                    self._device_id, key, raw, display, source, self.options,
+                )
+        return option
+
+    @property
+    def extra_state_attributes(self):
+        """Expose the raw API payload behind this select.
+
+        Useful when the option cannot be resolved: the attributes show which
+        endpoint and attribute name the value came from, and what it contained.
+        """
+        source, key, raw, display = self._read_source()
+        return {
+            "source": source,
+            "api_key": key,
+            "raw_value": raw,
+            "raw_display": display,
+        }
+
+
+class SolarOfThingsOperatingModeSelect(_BasePrioritySelect):
+    """Select entity for Output Source Priority.
+
+    Written as ``outputSourcePrioritySetting``; values 0/1/2 map to USO/SUB/SBU.
     """
+
+    _state_candidates = STATE_KEY_CANDIDATES["outputSourcePriority"]
+    _setting_candidates = SETTING_KEY_CANDIDATES["outputSourcePriority"]
+    _by_value = OUTPUT_PRIORITY_BY_VALUE
+    _aliases = OUTPUT_PRIORITY_ALIASES
 
     def __init__(self, api, coordinator, station_id: str, device_id: str, device_name: str) -> None:
         super().__init__(api, coordinator, station_id, device_id, device_name)
         self._attr_name = f"{device_name} Output Source Priority"
         self._attr_unique_id = f"{DOMAIN}_{station_id}_{device_id}_operating_mode"
-        self._attr_options = OUTPUT_MODES
+        self._attr_options = OUTPUT_PRIORITY_OPTIONS
         self._attr_icon = "mdi:cog"
-
-    @property
-    def current_option(self) -> str | None:
-        settings = ((self.coordinator.data or {}).get("settings") or {})
-        entry = settings.get("outputSourcePrioritySetting")
-        if entry is None:
-            return None
-        raw = entry.get("value") if isinstance(entry, dict) else entry
-        try:
-            return OUTPUT_MODE_BY_VALUE.get(int(raw))
-        except (TypeError, ValueError):
-            return None
 
     async def async_select_option(self, option: str) -> None:
         await self.hass.async_add_executor_job(self._api.set_operating_mode, self._device_id, option)
         await self.coordinator.async_request_refresh()
 
 
-class SolarOfThingsBatteryPrioritySelect(_BaseSelect):
-    """Select entity for Charger Source Priority (chargerSourcePrioritySetting).
+class SolarOfThingsBatteryPrioritySelect(_BasePrioritySelect):
+    """Select entity for Charger Source Priority.
 
-    Reflects the real device API key.  Values 0/1/2 map to CSO/SNU/OSO.
+    Written as ``chargerSourcePrioritySetting``; values 0/1/2 map to CSO/SNU/OSO.
     """
+
+    _state_candidates = STATE_KEY_CANDIDATES["chargerSourcePriority"]
+    _setting_candidates = SETTING_KEY_CANDIDATES["chargerSourcePriority"]
+    _by_value = CHARGER_PRIORITY_BY_VALUE
+    _aliases = CHARGER_PRIORITY_ALIASES
 
     def __init__(self, api, coordinator, station_id: str, device_id: str, device_name: str) -> None:
         super().__init__(api, coordinator, station_id, device_id, device_name)
         self._attr_name = f"{device_name} Charger Source Priority"
         self._attr_unique_id = f"{DOMAIN}_{station_id}_{device_id}_battery_priority"
-        self._attr_options = CHARGER_PRIORITIES
+        self._attr_options = CHARGER_PRIORITY_OPTIONS
         self._attr_icon = "mdi:battery-sync"
-
-    @property
-    def current_option(self) -> str | None:
-        settings = ((self.coordinator.data or {}).get("settings") or {})
-        entry = settings.get("chargerSourcePrioritySetting")
-        if entry is None:
-            return None
-        raw = entry.get("value") if isinstance(entry, dict) else entry
-        try:
-            return CHARGER_PRIORITY_BY_VALUE.get(int(raw))
-        except (TypeError, ValueError):
-            return None
 
     async def async_select_option(self, option: str) -> None:
         await self.hass.async_add_executor_job(self._api.set_battery_priority, self._device_id, option)

--- a/custom_components/solar_of_things/sensor.py
+++ b/custom_components/solar_of_things/sensor.py
@@ -7,10 +7,14 @@ from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, Sen
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
+    EntityCategory,
+    UnitOfApparentPower,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
+    UnitOfFrequency,
     UnitOfPower,
+    UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -71,6 +75,19 @@ async def async_setup_entry(
                     sensor_definition=definition,
                 )
             )
+
+        # State-endpoint sensors (temperature, voltages, freq, daily energy, mode)
+        for definition in STATE_SENSORS:
+            entities.append(
+                SolarOfThingsStateSensor(
+                    coordinator, station_id, device_id, device_name, definition
+                )
+            )
+
+        # Active-alarms sensor
+        entities.append(
+            SolarOfThingsAlarmSensor(coordinator, station_id, device_id, device_name)
+        )
 
     # Station-level monthly sensors
     if station_coordinator:
@@ -214,3 +231,111 @@ class SolarOfThingsStationMonthlySensor(CoordinatorEntity, SensorEntity):
             return round(float(val), 2)
         except Exception:
             return None
+
+
+# State-endpoint sensors (read from coordinator.data["state"]["fields"]).
+_SC, _DC = SensorStateClass, SensorDeviceClass
+STATE_SENSORS: list[dict] = [
+    {"key": "inverterHeatSinkTemperature", "name": "Inverter Temperature", "unit": UnitOfTemperature.CELSIUS, "device_class": _DC.TEMPERATURE, "state_class": _SC.MEASUREMENT, "icon": "mdi:thermometer"},
+    {"key": "busVoltage", "name": "Bus Voltage", "unit": UnitOfElectricPotential.VOLT, "device_class": _DC.VOLTAGE, "state_class": _SC.MEASUREMENT, "icon": "mdi:flash"},
+    {"key": "acOutputVoltage", "name": "AC Output Voltage", "unit": UnitOfElectricPotential.VOLT, "device_class": _DC.VOLTAGE, "state_class": _SC.MEASUREMENT, "icon": "mdi:sine-wave"},
+    {"key": "acOutputFrequency", "name": "AC Output Frequency", "unit": UnitOfFrequency.HERTZ, "device_class": _DC.FREQUENCY, "state_class": _SC.MEASUREMENT, "icon": "mdi:sine-wave"},
+    {"key": "acOutputApparentPower", "name": "AC Output Apparent Power", "unit": UnitOfApparentPower.VOLT_AMPERE, "device_class": _DC.APPARENT_POWER, "state_class": _SC.MEASUREMENT, "icon": "mdi:power-plug"},
+    {"key": "outputLoadPercent", "name": "Output Load", "unit": PERCENTAGE, "device_class": None, "state_class": _SC.MEASUREMENT, "icon": "mdi:gauge"},
+    {"key": "gridVoltage", "name": "Grid Voltage", "unit": UnitOfElectricPotential.VOLT, "device_class": _DC.VOLTAGE, "state_class": _SC.MEASUREMENT, "icon": "mdi:transmission-tower"},
+    {"key": "gridFrequency", "name": "Grid Frequency", "unit": UnitOfFrequency.HERTZ, "device_class": _DC.FREQUENCY, "state_class": _SC.MEASUREMENT, "icon": "mdi:transmission-tower"},
+    {"key": "PV1InputVoltage", "name": "PV1 Voltage", "unit": UnitOfElectricPotential.VOLT, "device_class": _DC.VOLTAGE, "state_class": _SC.MEASUREMENT, "icon": "mdi:solar-panel"},
+    {"key": "pv1InputCurrent", "name": "PV1 Current", "unit": UnitOfElectricCurrent.AMPERE, "device_class": _DC.CURRENT, "state_class": _SC.MEASUREMENT, "icon": "mdi:solar-panel"},
+    {"key": "PV1ChargingPower", "name": "PV1 Power", "unit": UnitOfPower.WATT, "device_class": _DC.POWER, "state_class": _SC.MEASUREMENT, "icon": "mdi:solar-power"},
+    {"key": "pvGeneratedEnergyOfDay", "name": "PV Generated", "unit": UnitOfEnergy.KILO_WATT_HOUR, "device_class": _DC.ENERGY, "state_class": _SC.TOTAL_INCREASING, "icon": "mdi:solar-power"},
+    # Diagnostic text sensors (current mode — useful while select read-back is unfixed)
+    {"key": "workingMode", "name": "Working Mode", "text": True, "diagnostic": True, "icon": "mdi:state-machine"},
+    {"key": "chargerSourcePriority", "name": "Charger Priority (current)", "text": True, "diagnostic": True, "icon": "mdi:battery-sync"},
+    {"key": "outputSourcePriority", "name": "Output Priority (current)", "text": True, "diagnostic": True, "icon": "mdi:cog"},
+    {"key": "chargingStatus", "name": "Charging Status", "text": True, "diagnostic": True, "icon": "mdi:battery-charging"},
+]
+
+
+class SolarOfThingsStateSensor(CoordinatorEntity, SensorEntity):
+    """Sensor reading a single field from the state/latest endpoint."""
+
+    def __init__(self, coordinator, station_id, device_id, device_name, definition):
+        super().__init__(coordinator)
+        self._station_id = station_id
+        self._device_id = device_id
+        self._device_name = device_name
+        self._key = definition["key"]
+        self._is_text = definition.get("text", False)
+        self._attr_has_entity_name = True
+        self._attr_name = definition["name"]
+        self._attr_unique_id = f"{DOMAIN}_{station_id}_{device_id}_state_{self._key}"
+        self._attr_icon = definition.get("icon")
+        if definition.get("diagnostic"):
+            self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        if not self._is_text:
+            self._attr_native_unit_of_measurement = definition.get("unit")
+            self._attr_device_class = definition.get("device_class")
+            self._attr_state_class = definition.get("state_class")
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._device_id)},
+            "name": self._device_name,
+            "manufacturer": "Siseli",
+            "via_device": (DOMAIN, self._station_id),
+        }
+
+    @property
+    def native_value(self):
+        fields = (((self.coordinator.data or {}).get("state") or {}).get("fields") or {})
+        entry = fields.get(self._key)
+        if not isinstance(entry, dict):
+            return None
+        if self._is_text:
+            disp = entry.get("valueDisplay")
+            return disp if disp not in (None, "") else entry.get("value")
+        val = entry.get("value")
+        if val in (None, ""):
+            return None
+        try:
+            return round(float(val), 2)
+        except (TypeError, ValueError):
+            return None
+
+
+class SolarOfThingsAlarmSensor(CoordinatorEntity, SensorEntity):
+    """Reports active (firing) device alarms; 'OK' when none."""
+
+    def __init__(self, coordinator, station_id, device_id, device_name):
+        super().__init__(coordinator)
+        self._station_id = station_id
+        self._device_id = device_id
+        self._device_name = device_name
+        self._attr_has_entity_name = True
+        self._attr_name = "Active Alarms"
+        self._attr_unique_id = f"{DOMAIN}_{station_id}_{device_id}_active_alarms"
+        self._attr_icon = "mdi:alert"
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._device_id)},
+            "name": self._device_name,
+            "manufacturer": "Siseli",
+            "via_device": (DOMAIN, self._station_id),
+        }
+
+    @property
+    def native_value(self):
+        alarms = ((self.coordinator.data or {}).get("state") or {}).get("firingAlarms") or []
+        names = [a.get("name") for a in alarms if isinstance(a, dict) and a.get("name")]
+        return ", ".join(names) if names else "OK"
+
+    @property
+    def extra_state_attributes(self):
+        alarms = ((self.coordinator.data or {}).get("state") or {}).get("firingAlarms") or []
+        return {
+            "count": len(alarms),
+            "alarms": [a.get("name") for a in alarms if isinstance(a, dict)],
+        }

--- a/custom_components/solar_of_things/sensor.py
+++ b/custom_components/solar_of_things/sensor.py
@@ -256,7 +256,17 @@ STATE_SENSORS: list[dict] = [
     {"key": "PV1InputVoltage", "name": "PV1 Voltage", "unit": UnitOfElectricPotential.VOLT, "device_class": _DC.VOLTAGE, "state_class": _SC.MEASUREMENT, "icon": "mdi:solar-panel"},
     {"key": "pv1InputCurrent", "name": "PV1 Current", "unit": UnitOfElectricCurrent.AMPERE, "device_class": _DC.CURRENT, "state_class": _SC.MEASUREMENT, "icon": "mdi:solar-panel"},
     {"key": "PV1ChargingPower", "name": "PV1 Power", "unit": UnitOfPower.WATT, "device_class": _DC.POWER, "state_class": _SC.MEASUREMENT, "icon": "mdi:solar-power"},
-    {"key": "pvGeneratedEnergyOfDay", "name": "PV Generated", "unit": UnitOfEnergy.KILO_WATT_HOUR, "device_class": _DC.ENERGY, "state_class": _SC.TOTAL_INCREASING, "icon": "mdi:solar-power"},
+    {"key": "PV2InputVoltage", "name": "PV2 Voltage", "unit": UnitOfElectricPotential.VOLT, "device_class": _DC.VOLTAGE, "state_class": _SC.MEASUREMENT, "icon": "mdi:solar-panel"},
+    {"key": "pv2InputCurrent", "name": "PV2 Current", "unit": UnitOfElectricCurrent.AMPERE, "device_class": _DC.CURRENT, "state_class": _SC.MEASUREMENT, "icon": "mdi:solar-panel"},
+    {"key": "PV2ChargingPower", "name": "PV2 Power", "unit": UnitOfPower.WATT, "device_class": _DC.POWER, "state_class": _SC.MEASUREMENT, "icon": "mdi:solar-power"},
+    # Despite the key name, the device reports lifetime PV production here —
+    # its own label is "Total photovoltaic power generation".
+    {"key": "pvGeneratedEnergyOfDay", "name": "PV Total Production", "unit": UnitOfEnergy.KILO_WATT_HOUR, "device_class": _DC.ENERGY, "state_class": _SC.TOTAL_INCREASING, "icon": "mdi:solar-power"},
+    {"key": "batteryFloatVoltage", "name": "Battery Float Voltage", "unit": UnitOfElectricPotential.VOLT, "device_class": _DC.VOLTAGE, "state_class": _SC.MEASUREMENT, "diagnostic": True, "icon": "mdi:battery-heart-variant"},
+    {"key": "batteryBulkVoltage", "name": "Battery Bulk Voltage", "unit": UnitOfElectricPotential.VOLT, "device_class": _DC.VOLTAGE, "state_class": _SC.MEASUREMENT, "diagnostic": True, "icon": "mdi:battery-heart-variant"},
+    {"key": "optionalValueForMaximumChargingCurrent", "name": "Max Charging Current", "unit": UnitOfElectricCurrent.AMPERE, "device_class": _DC.CURRENT, "state_class": _SC.MEASUREMENT, "diagnostic": True, "icon": "mdi:battery-arrow-up"},
+    {"key": "optionalMaximumUtilityChargingCurrent", "name": "Max Utility Charging Current", "unit": UnitOfElectricCurrent.AMPERE, "device_class": _DC.CURRENT, "state_class": _SC.MEASUREMENT, "diagnostic": True, "icon": "mdi:transmission-tower-import"},
+    {"key": "maxDischargingCurren", "name": "Max Discharging Current", "unit": UnitOfElectricCurrent.AMPERE, "device_class": _DC.CURRENT, "state_class": _SC.MEASUREMENT, "diagnostic": True, "icon": "mdi:battery-arrow-down"},
     # Diagnostic text sensors reporting the mode the device is actually in.
     # These read the same snapshot fields as the select entities, so they are a
     # quick way to see the raw label the API returned for a mode.
@@ -264,6 +274,15 @@ STATE_SENSORS: list[dict] = [
     {"key": "chargerSourcePriority", "name": "Charger Priority (current)", "text": True, "diagnostic": True, "icon": "mdi:battery-sync", "candidates": STATE_KEY_CANDIDATES["chargerSourcePriority"]},
     {"key": "outputSourcePriority", "name": "Output Priority (current)", "text": True, "diagnostic": True, "icon": "mdi:cog", "candidates": STATE_KEY_CANDIDATES["outputSourcePriority"]},
     {"key": "chargingStatus", "name": "Charging Status", "text": True, "diagnostic": True, "icon": "mdi:battery-charging"},
+    {"key": "acChargingStatus", "name": "AC Charging Status", "text": True, "diagnostic": True, "icon": "mdi:transmission-tower-import"},
+    {"key": "sccChargingStatus", "name": "Solar Charging Status", "text": True, "diagnostic": True, "icon": "mdi:solar-power"},
+    # Read-only: the device reports its input voltage range but the portal
+    # exposes no write key for it, so this is a sensor rather than a switch.
+    {"key": "inputVoltageRange", "name": "Input Voltage Range", "text": True, "diagnostic": True, "icon": "mdi:sine-wave", "candidates": STATE_KEY_CANDIDATES["acInputRange"]},
+    {"key": "loadStatus", "name": "Load Status", "text": True, "diagnostic": True, "icon": "mdi:power-plug"},
+    {"key": "modelName", "name": "Model", "text": True, "diagnostic": True, "icon": "mdi:information-outline"},
+    {"key": "serialNumber", "name": "Serial Number", "text": True, "diagnostic": True, "icon": "mdi:identifier"},
+    {"key": "mainCpuFirmwareVersion", "name": "Firmware Version", "text": True, "diagnostic": True, "icon": "mdi:chip"},
 ]
 
 # device_class → the unit family used to normalise a snapshot reading.

--- a/custom_components/solar_of_things/sensor.py
+++ b/custom_components/solar_of_things/sensor.py
@@ -20,7 +20,16 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, SENSOR_DEFINITIONS
+from .const import DOMAIN, SENSOR_DEFINITIONS, STATE_KEY_CANDIDATES
+from .helpers import (
+    entry_display,
+    entry_unit,
+    entry_value,
+    find_entry,
+    scale_value,
+    state_fields,
+    to_float,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -248,12 +257,20 @@ STATE_SENSORS: list[dict] = [
     {"key": "pv1InputCurrent", "name": "PV1 Current", "unit": UnitOfElectricCurrent.AMPERE, "device_class": _DC.CURRENT, "state_class": _SC.MEASUREMENT, "icon": "mdi:solar-panel"},
     {"key": "PV1ChargingPower", "name": "PV1 Power", "unit": UnitOfPower.WATT, "device_class": _DC.POWER, "state_class": _SC.MEASUREMENT, "icon": "mdi:solar-power"},
     {"key": "pvGeneratedEnergyOfDay", "name": "PV Generated", "unit": UnitOfEnergy.KILO_WATT_HOUR, "device_class": _DC.ENERGY, "state_class": _SC.TOTAL_INCREASING, "icon": "mdi:solar-power"},
-    # Diagnostic text sensors (current mode — useful while select read-back is unfixed)
+    # Diagnostic text sensors reporting the mode the device is actually in.
+    # These read the same snapshot fields as the select entities, so they are a
+    # quick way to see the raw label the API returned for a mode.
     {"key": "workingMode", "name": "Working Mode", "text": True, "diagnostic": True, "icon": "mdi:state-machine"},
-    {"key": "chargerSourcePriority", "name": "Charger Priority (current)", "text": True, "diagnostic": True, "icon": "mdi:battery-sync"},
-    {"key": "outputSourcePriority", "name": "Output Priority (current)", "text": True, "diagnostic": True, "icon": "mdi:cog"},
+    {"key": "chargerSourcePriority", "name": "Charger Priority (current)", "text": True, "diagnostic": True, "icon": "mdi:battery-sync", "candidates": STATE_KEY_CANDIDATES["chargerSourcePriority"]},
+    {"key": "outputSourcePriority", "name": "Output Priority (current)", "text": True, "diagnostic": True, "icon": "mdi:cog", "candidates": STATE_KEY_CANDIDATES["outputSourcePriority"]},
     {"key": "chargingStatus", "name": "Charging Status", "text": True, "diagnostic": True, "icon": "mdi:battery-charging"},
 ]
+
+# device_class → the unit family used to normalise a snapshot reading.
+_SCALE_KIND_BY_DEVICE_CLASS = {
+    _DC.POWER: "power",
+    _DC.ENERGY: "energy",
+}
 
 
 class SolarOfThingsStateSensor(CoordinatorEntity, SensorEntity):
@@ -265,7 +282,9 @@ class SolarOfThingsStateSensor(CoordinatorEntity, SensorEntity):
         self._device_id = device_id
         self._device_name = device_name
         self._key = definition["key"]
+        self._candidates = definition.get("candidates") or [self._key]
         self._is_text = definition.get("text", False)
+        self._scale_kind = _SCALE_KIND_BY_DEVICE_CLASS.get(definition.get("device_class"))
         self._attr_has_entity_name = True
         self._attr_name = definition["name"]
         self._attr_unique_id = f"{DOMAIN}_{station_id}_{device_id}_state_{self._key}"
@@ -288,20 +307,24 @@ class SolarOfThingsStateSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def native_value(self):
-        fields = (((self.coordinator.data or {}).get("state") or {}).get("fields") or {})
-        entry = fields.get(self._key)
-        if not isinstance(entry, dict):
+        # Candidate lookup is case-insensitive: the snapshot is inconsistent
+        # about capitalisation (PV1InputVoltage vs pv1InputCurrent) and some
+        # models publish a measurement under an alternative name entirely.
+        _key, entry = find_entry(
+            state_fields((self.coordinator.data or {}).get("state")), self._candidates
+        )
+        if entry is None:
             return None
+
         if self._is_text:
-            disp = entry.get("valueDisplay")
-            return disp if disp not in (None, "") else entry.get("value")
-        val = entry.get("value")
-        if val in (None, ""):
+            display = entry_display(entry)
+            value = display if display not in (None, "") else entry_value(entry)
+            return value if value not in (None, "") else None
+
+        number = to_float(entry_value(entry))
+        if number is None:
             return None
-        try:
-            return round(float(val), 2)
-        except (TypeError, ValueError):
-            return None
+        return round(scale_value(number, entry_unit(entry), self._scale_kind), 2)
 
 
 class SolarOfThingsAlarmSensor(CoordinatorEntity, SensorEntity):

--- a/custom_components/solar_of_things/switch.py
+++ b/custom_components/solar_of_things/switch.py
@@ -1,10 +1,13 @@
 """Switch platform for Solar of Things integration.
 
-Like the selects, these switches read their state from the live snapshot
-(``/apis/deviceState/simple/state/latest/v1``) first and only fall back to the
-remote-config cache, which is empty until something has been written through
-the portal.  Both integer codes and word renderings ("ON", "Appliance") are
-accepted, because the snapshot reports some controls as text.
+Each switch maps to one entry in ``BOOLEAN_CONTROLS``: it reads the live state
+snapshot (falling back to the remote-config cache) and writes through the
+remote-config endpoint under that control's *setting* key.
+
+The pre-2.6.0 "Grid Charging (AC Input Range)" switch is gone.  Input voltage
+range is reported by the device (``inputVoltageRange``) but the portal exposes
+no write key for it, so the switch could never actually change anything; it is
+now a read-only diagnostic sensor instead.
 """
 from __future__ import annotations
 
@@ -18,6 +21,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
+    BOOLEAN_CONTROLS,
     DOMAIN,
     OUTPUT_PRIORITY_ALIASES,
     OUTPUT_PRIORITY_BY_VALUE,
@@ -37,8 +41,8 @@ from .helpers import (
 _LOGGER = logging.getLogger(__name__)
 
 # Word renderings the state snapshot uses instead of a numeric code.
-_TRUE_WORDS = {"on", "enable", "enabled", "true", "yes", "appliance"}
-_FALSE_WORDS = {"off", "disable", "disabled", "false", "no", "ups"}
+_TRUE_WORDS = {"on", "enable", "enabled", "true", "yes"}
+_FALSE_WORDS = {"off", "disable", "disabled", "false", "no"}
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
@@ -51,13 +55,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
     for device_id, coordinator in device_coordinators.items():
         device_name = (coordinator.device_meta or {}).get("name") or device_id
-        entities.extend(
-            [
-                SolarOfThingsGridChargingSwitch(api, coordinator, station_id, device_id, device_name),
-                SolarOfThingsGridFeedInSwitch(api, coordinator, station_id, device_id, device_name),
-                SolarOfThingsBackupModeSwitch(api, coordinator, station_id, device_id, device_name),
-            ]
+        entities.append(
+            SolarOfThingsBackupModeSwitch(api, coordinator, station_id, device_id, device_name)
         )
+        for control, spec in BOOLEAN_CONTROLS.items():
+            entities.append(
+                SolarOfThingsControlSwitch(
+                    api, coordinator, station_id, device_id, device_name, control, spec
+                )
+            )
 
     async_add_entities(entities)
 
@@ -67,8 +73,8 @@ def _control_entries(
 ) -> Iterator[tuple[str, str, Any]]:
     """Yield ``(source, matched_key, entry)`` for a control, snapshot first.
 
-    *control* is a key of ``STATE_KEY_CANDIDATES`` / ``SETTING_KEY_CANDIDATES``;
-    each maps to the list of attribute names different models use.
+    The remote-config cache only holds values previously written through the
+    portal, so it is a fallback rather than the primary source.
     """
     data = coordinator_data or {}
 
@@ -86,13 +92,13 @@ def _control_entries(
 
 
 def _setting_bool(
-    coordinator_data: dict | None, control: str, on_values: set[int]
+    coordinator_data: dict | None, control: str, on_codes: set[int]
 ) -> bool | None:
     """Resolve a control to on/off, accepting both codes and word renderings."""
     for _source, _key, entry in _control_entries(coordinator_data, control):
         number = to_float(entry_value(entry))
         if number is not None and number == int(number):
-            return int(number) in on_values
+            return int(number) in on_codes
         for text in (entry_display(entry), entry_value(entry)):
             word = normalise_text(text)
             if word in _TRUE_WORDS:
@@ -109,6 +115,8 @@ class _BaseSwitch(CoordinatorEntity, SwitchEntity):
         self._station_id = station_id
         self._device_id = device_id
         self._device_name = device_name
+        self._attr_has_entity_name = True
+        self._attr_device_class = SwitchDeviceClass.SWITCH
 
     @property
     def device_info(self):
@@ -121,83 +129,57 @@ class _BaseSwitch(CoordinatorEntity, SwitchEntity):
         }
 
 
-class SolarOfThingsGridChargingSwitch(_BaseSwitch):
-    """Switch for AC Input Range setting (acInputRangeSetting).
+class SolarOfThingsControlSwitch(_BaseSwitch):
+    """Switch for one of the device's enable/disable settings."""
 
-    0 = Appliance mode – wide input voltage range, grid charging allowed.
-    1 = UPS mode – narrow voltage range, stricter bypass behaviour.
-    The switch reports ON when the inverter is in Appliance (grid-charging) mode.
-    """
-
-    def __init__(self, api, coordinator, station_id: str, device_id: str, device_name: str) -> None:
+    def __init__(
+        self, api, coordinator, station_id: str, device_id: str, device_name: str,
+        control: str, spec: dict,
+    ) -> None:
         super().__init__(api, coordinator, station_id, device_id, device_name)
-        self._attr_name = f"{device_name} Grid Charging (AC Input Range)"
-        self._attr_unique_id = f"{DOMAIN}_{station_id}_{device_id}_grid_charging"
-        self._attr_device_class = SwitchDeviceClass.SWITCH
-        self._attr_icon = "mdi:transmission-tower"
+        self._control = control
+        self._on_codes: set[int] = spec["on_codes"]
+        self._attr_name = spec["name"]
+        self._attr_unique_id = f"{DOMAIN}_{station_id}_{device_id}_{control}"
+        self._attr_icon = spec.get("icon")
 
     @property
     def is_on(self) -> bool | None:
-        # 0 = Appliance (charging OK), 1 = UPS (bypass).
-        return _setting_bool(self.coordinator.data, "acInputRange", {0})
+        return _setting_bool(self.coordinator.data, self._control, self._on_codes)
 
     async def async_turn_on(self, **kwargs):
-        await self.hass.async_add_executor_job(self._api.set_grid_charging, self._device_id, True)
-        await self.coordinator.async_request_refresh()
+        await self._async_write(True)
 
     async def async_turn_off(self, **kwargs):
-        await self.hass.async_add_executor_job(self._api.set_grid_charging, self._device_id, False)
-        await self.coordinator.async_request_refresh()
+        await self._async_write(False)
 
-
-class SolarOfThingsGridFeedInSwitch(_BaseSwitch):
-    """Switch for GRID grid switch (batteryPowerLimitingSetting).
-
-    0 = OFF (grid switch disabled / feed-in off).
-    1 = ON  (grid switch enabled / feed-in on).
-    """
-
-    def __init__(self, api, coordinator, station_id: str, device_id: str, device_name: str) -> None:
-        super().__init__(api, coordinator, station_id, device_id, device_name)
-        self._attr_name = f"{device_name} Grid Feed-In"
-        self._attr_unique_id = f"{DOMAIN}_{station_id}_{device_id}_grid_feed_in"
-        self._attr_device_class = SwitchDeviceClass.SWITCH
-        self._attr_icon = "mdi:transmission-tower-export"
-
-    @property
-    def is_on(self) -> bool | None:
-        return _setting_bool(self.coordinator.data, "gridFeedIn", {1})
-
-    async def async_turn_on(self, **kwargs):
-        await self.hass.async_add_executor_job(self._api.set_grid_feed_in, self._device_id, True)
-        await self.coordinator.async_request_refresh()
-
-    async def async_turn_off(self, **kwargs):
-        await self.hass.async_add_executor_job(self._api.set_grid_feed_in, self._device_id, False)
+    async def _async_write(self, enabled: bool) -> None:
+        await self.hass.async_add_executor_job(
+            self._api.set_boolean_control, self._device_id, self._control, enabled
+        )
         await self.coordinator.async_request_refresh()
 
 
 class SolarOfThingsBackupModeSwitch(_BaseSwitch):
-    """Switch that maps to Output Source Priority SBU (backup/off-grid biased).
+    """Shortcut that maps to Output Source Priority SBU (backup/off-grid biased).
 
-    ON  → outputSourcePrioritySetting = 2 (SBU: Solar+Battery first, grid last).
-    OFF → outputSourcePrioritySetting = 1 (SUB: Solar first, grid as supplement).
+    ON  → Solar+Battery First (SBU): grid is the last resort.
+    OFF → Solar First (SUB): solar first, grid supplements before the battery.
 
-    Note: turning this switch ON will also change the Output Source Priority
-    select to 'Solar+Battery First (SBU)', which is the expected behaviour.
+    Turning this on also moves the Output Source Priority select, which is the
+    expected behaviour — they are the same device setting.
     """
 
     def __init__(self, api, coordinator, station_id: str, device_id: str, device_name: str) -> None:
         super().__init__(api, coordinator, station_id, device_id, device_name)
-        self._attr_name = f"{device_name} Backup Mode (SBU Priority)"
+        self._attr_name = "Backup Mode (SBU Priority)"
         self._attr_unique_id = f"{DOMAIN}_{station_id}_{device_id}_backup_mode"
-        self._attr_device_class = SwitchDeviceClass.SWITCH
         self._attr_icon = "mdi:battery-lock"
 
     @property
     def is_on(self) -> bool | None:
-        # Resolved through the same option table as the select, so an SBU
-        # reported as the string "SBU" counts as on just like the code 2 does.
+        # Resolved through the same option table as the select, so a mode
+        # reported as a label rather than a code still counts.
         for _source, _key, entry in _control_entries(
             self.coordinator.data, "outputSourcePriority"
         ):

--- a/custom_components/solar_of_things/switch.py
+++ b/custom_components/solar_of_things/switch.py
@@ -1,7 +1,15 @@
-"""Switch platform for Solar of Things integration."""
+"""Switch platform for Solar of Things integration.
+
+Like the selects, these switches read their state from the live snapshot
+(``/apis/deviceState/simple/state/latest/v1``) first and only fall back to the
+remote-config cache, which is empty until something has been written through
+the portal.  Both integer codes and word renderings ("ON", "Appliance") are
+accepted, because the snapshot reports some controls as text.
+"""
 from __future__ import annotations
 
 import logging
+from typing import Any, Iterator
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
@@ -9,9 +17,28 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import (
+    DOMAIN,
+    OUTPUT_PRIORITY_ALIASES,
+    OUTPUT_PRIORITY_BY_VALUE,
+    SETTING_KEY_CANDIDATES,
+    STATE_KEY_CANDIDATES,
+)
+from .helpers import (
+    entry_display,
+    entry_value,
+    find_entry,
+    normalise_text,
+    resolve_option,
+    state_fields,
+    to_float,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+# Word renderings the state snapshot uses instead of a numeric code.
+_TRUE_WORDS = {"on", "enable", "enabled", "true", "yes", "appliance"}
+_FALSE_WORDS = {"off", "disable", "disabled", "false", "no", "ups"}
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
@@ -35,17 +62,44 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     async_add_entities(entities)
 
 
-def _setting_value(coordinator_data: dict | None, key: str) -> int | None:
-    """Extract the integer value for a device setting key from coordinator data."""
-    settings = ((coordinator_data or {}).get("settings") or {})
-    entry = settings.get(key)
-    if entry is None:
-        return None
-    raw = entry.get("value") if isinstance(entry, dict) else entry
-    try:
-        return int(raw)
-    except (TypeError, ValueError):
-        return None
+def _control_entries(
+    coordinator_data: dict | None, control: str
+) -> Iterator[tuple[str, str, Any]]:
+    """Yield ``(source, matched_key, entry)`` for a control, snapshot first.
+
+    *control* is a key of ``STATE_KEY_CANDIDATES`` / ``SETTING_KEY_CANDIDATES``;
+    each maps to the list of attribute names different models use.
+    """
+    data = coordinator_data or {}
+
+    key, entry = find_entry(
+        state_fields(data.get("state")), STATE_KEY_CANDIDATES.get(control, [control])
+    )
+    if entry is not None:
+        yield "state", key, entry
+
+    key, entry = find_entry(
+        data.get("settings") or {}, SETTING_KEY_CANDIDATES.get(control, [control])
+    )
+    if entry is not None:
+        yield "settings", key, entry
+
+
+def _setting_bool(
+    coordinator_data: dict | None, control: str, on_values: set[int]
+) -> bool | None:
+    """Resolve a control to on/off, accepting both codes and word renderings."""
+    for _source, _key, entry in _control_entries(coordinator_data, control):
+        number = to_float(entry_value(entry))
+        if number is not None and number == int(number):
+            return int(number) in on_values
+        for text in (entry_display(entry), entry_value(entry)):
+            word = normalise_text(text)
+            if word in _TRUE_WORDS:
+                return True
+            if word in _FALSE_WORDS:
+                return False
+    return None
 
 
 class _BaseSwitch(CoordinatorEntity, SwitchEntity):
@@ -84,10 +138,8 @@ class SolarOfThingsGridChargingSwitch(_BaseSwitch):
 
     @property
     def is_on(self) -> bool | None:
-        val = _setting_value(self.coordinator.data, "acInputRangeSetting")
-        if val is None:
-            return None
-        return val == 0  # 0=Appliance (charging OK), 1=UPS (bypass)
+        # 0 = Appliance (charging OK), 1 = UPS (bypass).
+        return _setting_bool(self.coordinator.data, "acInputRange", {0})
 
     async def async_turn_on(self, **kwargs):
         await self.hass.async_add_executor_job(self._api.set_grid_charging, self._device_id, True)
@@ -114,10 +166,7 @@ class SolarOfThingsGridFeedInSwitch(_BaseSwitch):
 
     @property
     def is_on(self) -> bool | None:
-        val = _setting_value(self.coordinator.data, "batteryPowerLimitingSetting")
-        if val is None:
-            return None
-        return val == 1  # 1=ON
+        return _setting_bool(self.coordinator.data, "gridFeedIn", {1})
 
     async def async_turn_on(self, **kwargs):
         await self.hass.async_add_executor_job(self._api.set_grid_feed_in, self._device_id, True)
@@ -134,8 +183,8 @@ class SolarOfThingsBackupModeSwitch(_BaseSwitch):
     ON  → outputSourcePrioritySetting = 2 (SBU: Solar+Battery first, grid last).
     OFF → outputSourcePrioritySetting = 1 (SUB: Solar first, grid as supplement).
 
-    Note: turning this switch ON will also change the Operating Mode select entity
-    to 'Solar+Battery First (SBU)', which is the expected behaviour.
+    Note: turning this switch ON will also change the Output Source Priority
+    select to 'Solar+Battery First (SBU)', which is the expected behaviour.
     """
 
     def __init__(self, api, coordinator, station_id: str, device_id: str, device_name: str) -> None:
@@ -147,10 +196,20 @@ class SolarOfThingsBackupModeSwitch(_BaseSwitch):
 
     @property
     def is_on(self) -> bool | None:
-        val = _setting_value(self.coordinator.data, "outputSourcePrioritySetting")
-        if val is None:
-            return None
-        return val == 2  # SBU
+        # Resolved through the same option table as the select, so an SBU
+        # reported as the string "SBU" counts as on just like the code 2 does.
+        for _source, _key, entry in _control_entries(
+            self.coordinator.data, "outputSourcePriority"
+        ):
+            option = resolve_option(
+                entry_value(entry),
+                entry_display(entry),
+                OUTPUT_PRIORITY_BY_VALUE,
+                OUTPUT_PRIORITY_ALIASES,
+            )
+            if option is not None:
+                return option == OUTPUT_PRIORITY_BY_VALUE[2]
+        return None
 
     async def async_turn_on(self, **kwargs):
         await self.hass.async_add_executor_job(self._api.set_backup_mode, self._device_id, True)

--- a/tests/_component.py
+++ b/tests/_component.py
@@ -1,0 +1,27 @@
+"""Import integration submodules without requiring Home Assistant.
+
+``custom_components/solar_of_things/__init__.py`` imports Home Assistant, so a
+plain ``import custom_components.solar_of_things.helpers`` drags the whole HA
+runtime in.  The pure-logic modules (const, helpers, api) have no HA imports at
+all, so they are loaded here under a private package name whose ``__path__``
+points at the component directory — the real package ``__init__`` never runs.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+_PACKAGE = "_solar_of_things_under_test"
+_COMPONENT_DIR = Path(__file__).resolve().parent.parent / "custom_components" / "solar_of_things"
+
+
+def load(module: str) -> Any:
+    """Return the named integration submodule (e.g. ``"helpers"``)."""
+    if _PACKAGE not in sys.modules:
+        package = types.ModuleType(_PACKAGE)
+        package.__path__ = [str(_COMPONENT_DIR)]
+        sys.modules[_PACKAGE] = package
+    return importlib.import_module(f"{_PACKAGE}.{module}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,36 @@
-"""Test configuration for Solar of Things integration."""
-import pytest
-from homeassistant.core import HomeAssistant
-from homeassistant.config_entries import ConfigEntry
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+"""Test configuration for Solar of Things integration.
 
-from custom_components.solar_of_things.const import DOMAIN
+Home Assistant is an optional test dependency: the pure-logic tests
+(``test_value_resolution.py``) run without it, so the HA imports are guarded
+and the fixtures that need it skip instead of breaking collection for the
+whole directory.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _component import load  # noqa: E402 — needs the path insertion above
+
+try:
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    HA_AVAILABLE = True
+except ImportError:  # pragma: no cover — depends on the environment
+    MockConfigEntry = None
+    HA_AVAILABLE = False
+
+# Loaded without importing the package __init__, which pulls in Home Assistant.
+DOMAIN = load("const").DOMAIN
 
 
 @pytest.fixture
-def mock_config_entry() -> ConfigEntry:
+def mock_config_entry():
     """Return a mock config entry."""
+    if not HA_AVAILABLE:
+        pytest.skip("Home Assistant test harness is not installed")
     return MockConfigEntry(
         domain=DOMAIN,
         data={

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,9 +1,16 @@
-"""Test the Solar of Things config flow."""
+"""Test the Solar of Things config flow.
+
+Requires a Home Assistant test harness (``pytest-homeassistant-custom-component``);
+the module skips itself when one is not installed.
+"""
 from unittest.mock import patch
 
 import pytest
-from homeassistant import config_entries, data_entry_flow
-from homeassistant.core import HomeAssistant
+
+pytest.importorskip("homeassistant", reason="Home Assistant is not installed")
+
+from homeassistant import config_entries, data_entry_flow  # noqa: E402
+from homeassistant.core import HomeAssistant  # noqa: E402
 
 from custom_components.solar_of_things.const import DOMAIN
 

--- a/tests/test_value_resolution.py
+++ b/tests/test_value_resolution.py
@@ -1,0 +1,185 @@
+"""Tests for the payload-shape handling that drives the entity read-back.
+
+These cover the failure modes reported against 2.4.x: priority selects stuck on
+``unknown`` because the settings cache was empty, and Grid Feed-in Power stuck
+on ``unknown`` because the model publishes it under another name.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _component import load  # noqa: E402  — needs the path insertion above
+
+api = load("api")
+const = load("const")
+helpers = load("helpers")
+
+
+# ── state_fields ──────────────────────────────────────────────────────────────
+
+def test_state_fields_accepts_unwrapped_payload():
+    assert helpers.state_fields({"fields": {"a": {"value": 1}}}) == {"a": {"value": 1}}
+
+
+def test_state_fields_accepts_data_wrapped_payload():
+    payload = {"data": {"fields": {"a": {"value": 1}}}}
+    assert helpers.state_fields(payload) == {"a": {"value": 1}}
+
+
+def test_state_fields_of_empty_payload_is_empty():
+    assert helpers.state_fields(None) == {}
+    assert helpers.state_fields({}) == {}
+
+
+# ── find_entry ────────────────────────────────────────────────────────────────
+
+def test_find_entry_is_case_insensitive():
+    fields = {"PV1InputVoltage": {"value": 230}}
+    key, entry = helpers.find_entry(fields, ["pv1inputvoltage"])
+    assert key == "PV1InputVoltage"
+    assert entry == {"value": 230}
+
+
+def test_find_entry_returns_first_matching_candidate():
+    fields = {"gridFeedInPower": {"value": 5}, "feedbackPower": {"value": 9}}
+    key, _entry = helpers.find_entry(fields, ["feedInPower", "gridFeedInPower", "feedbackPower"])
+    assert key == "gridFeedInPower"
+
+
+def test_find_entry_without_match():
+    assert helpers.find_entry({"a": {}}, ["b", "c"]) == (None, None)
+
+
+# ── numbers and units ─────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [(1, 1.0), ("2.5", 2.5), ("1234.5 W", 1234.5), ("", None), (None, None), ("abc", None), (True, None)],
+)
+def test_to_float(raw, expected):
+    assert helpers.to_float(raw) == expected
+
+
+def test_state_number_scales_kilowatts_to_watts():
+    fields = {"feedInPower": {"value": 1.5, "unit": "kW"}}
+    assert helpers.state_number(fields, ["feedInPower"], "power") == 1500.0
+
+
+def test_state_number_leaves_watts_alone():
+    fields = {"feedInPower": {"value": 1500, "unit": "W"}}
+    assert helpers.state_number(fields, ["feedInPower"], "power") == 1500.0
+
+
+def test_state_number_passes_through_unknown_unit():
+    fields = {"feedInPower": {"value": 1500, "unit": "??"}}
+    assert helpers.state_number(fields, ["feedInPower"], "power") == 1500.0
+
+
+# ── option resolution ─────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    ("raw", "display", "expected"),
+    [
+        (2, None, "Solar+Battery First (SBU)"),
+        ("2", None, "Solar+Battery First (SBU)"),
+        (None, "SBU", "Solar+Battery First (SBU)"),
+        (None, "Solar+Battery first (SBU)", "Solar+Battery First (SBU)"),
+        (None, "Utility first", "Utility First (USO)"),
+        (0, "Utility First (USO)", "Utility First (USO)"),
+        (None, "something else entirely", None),
+        (None, None, None),
+    ],
+)
+def test_resolve_output_priority(raw, display, expected):
+    assert helpers.resolve_option(
+        raw, display, const.OUTPUT_PRIORITY_BY_VALUE, const.OUTPUT_PRIORITY_ALIASES
+    ) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "display", "expected"),
+    [
+        (0, None, "Solar + Utility (CSO)"),
+        (None, "SNU", "Solar First (SNU)"),
+        (None, "Solar only", "Solar Only (OSO)"),
+        (7, None, None),
+    ],
+)
+def test_resolve_charger_priority(raw, display, expected):
+    assert helpers.resolve_option(
+        raw, display, const.CHARGER_PRIORITY_BY_VALUE, const.CHARGER_PRIORITY_ALIASES
+    ) == expected
+
+
+def test_every_option_label_resolves_to_itself():
+    """The labels we send back to the API must survive a round trip."""
+    for by_value, aliases in (
+        (const.OUTPUT_PRIORITY_BY_VALUE, const.OUTPUT_PRIORITY_ALIASES),
+        (const.CHARGER_PRIORITY_BY_VALUE, const.CHARGER_PRIORITY_ALIASES),
+    ):
+        for label in by_value.values():
+            assert helpers.resolve_option(None, label, by_value, aliases) == label
+
+
+# ── telemetry fallbacks ───────────────────────────────────────────────────────
+
+def test_merge_state_fallbacks_fills_feed_in_power_from_alias():
+    latest = {"acOutputActivePower": 2000.0, "pvInputPower": 1000.0}
+    state = {"fields": {"gridFeedInPower": {"value": 0.4, "unit": "kW"}}}
+
+    merged = api.merge_state_fallbacks(latest, state)
+
+    assert merged["feedInPower"] == 400.0
+
+
+def test_merge_state_fallbacks_does_not_override_existing_values():
+    latest = {"feedInPower": 123.0}
+    state = {"fields": {"feedInPower": {"value": 999}}}
+
+    assert api.merge_state_fallbacks(latest, state)["feedInPower"] == 123.0
+
+
+def test_merge_state_fallbacks_recomputes_derived_values():
+    latest = {"acOutputActivePower": 2000.0, "pvInputPower": 500.0}
+    state = {
+        "fields": {
+            "batteryVoltage": {"value": 48},
+            "batteryDischargeCurrent": {"value": 10},
+            "batteryChargingCurrent": {"value": 0},
+            "feedInPower": {"value": 0},
+        }
+    }
+
+    merged = api.merge_state_fallbacks(latest, state)
+
+    assert merged["batteryPower"] == 480.0
+    assert merged["loadPower"] == 2000.0
+    # ac_output - pv + battery + feed_in = 2000 - 500 + 480 + 0
+    assert merged["gridPower"] == 1980.0
+
+
+def test_merge_state_fallbacks_without_state_is_a_noop():
+    latest = {"acOutputActivePower": 100.0}
+    assert api.merge_state_fallbacks(dict(latest), {}) == latest
+
+
+def test_grid_power_never_goes_negative():
+    values = api.compute_derived_values({"acOutputActivePower": 100.0, "pvInputPower": 5000.0})
+    assert values["gridPower"] == 0.0
+
+
+# ── key tables ────────────────────────────────────────────────────────────────
+
+def test_state_and_setting_candidate_tables_cover_the_same_controls():
+    assert set(const.STATE_KEY_CANDIDATES) == set(const.SETTING_KEY_CANDIDATES)
+
+
+def test_api_write_maps_match_the_select_options():
+    """The labels the selects offer must be exactly the ones the API can write."""
+    assert set(api.SolarOfThingsAPI._OUTPUT_MODE_MAP) == set(const.OUTPUT_PRIORITY_OPTIONS)
+    assert set(api.SolarOfThingsAPI._CHARGER_PRIORITY_MAP) == set(const.CHARGER_PRIORITY_OPTIONS)

--- a/tests/test_value_resolution.py
+++ b/tests/test_value_resolution.py
@@ -104,15 +104,38 @@ def test_resolve_output_priority(raw, display, expected):
 @pytest.mark.parametrize(
     ("raw", "display", "expected"),
     [
-        (0, None, "Solar + Utility (CSO)"),
-        (None, "SNU", "Solar First (SNU)"),
-        (None, "Solar only", "Solar Only (OSO)"),
+        # Straight from a live PI30/VMIII snapshot: code 3 with this label.
+        ("3", "Only Solar Permitted", "Solar Only"),
+        ("1", "for solar first", "Solar First"),
+        (0, None, "Utility First"),
+        (2, None, "Solar + Utility"),
+        (None, "Solar only", "Solar Only"),
         (7, None, None),
     ],
 )
 def test_resolve_charger_priority(raw, display, expected):
     assert helpers.resolve_option(
         raw, display, const.CHARGER_PRIORITY_BY_VALUE, const.CHARGER_PRIORITY_ALIASES
+    ) == expected
+
+
+def test_charger_priority_covers_all_four_pi30_codes():
+    """PCP is 0-3; treating it as 0-2 is what broke read-back before 2.6.0."""
+    assert sorted(const.CHARGER_PRIORITY_BY_VALUE) == [0, 1, 2, 3]
+
+
+@pytest.mark.parametrize(
+    ("raw", "display", "expected"),
+    [
+        ("1", "Photovoltaic ->mains power ->battery", "Solar First (SUB)"),
+        (None, "SolarUtilityBat", "Solar First (SUB)"),
+        (None, "SolarBatUtility", "Solar+Battery First (SBU)"),
+        (None, "UtilitySolarBat", "Utility First (USO)"),
+    ],
+)
+def test_resolve_output_priority_from_live_labels(raw, display, expected):
+    assert helpers.resolve_option(
+        raw, display, const.OUTPUT_PRIORITY_BY_VALUE, const.OUTPUT_PRIORITY_ALIASES
     ) == expected
 
 
@@ -127,6 +150,50 @@ def test_every_option_label_resolves_to_itself():
 
 
 # ── telemetry fallbacks ───────────────────────────────────────────────────────
+
+# Trimmed from a live PI30 / VMIII snapshot (state/latest, dataSource=1).
+LIVE_STATE = {
+    "fields": {
+        "generationPower": {"unit": "kW", "value": 1.162, "valueDisplay": "1.162"},
+        "acOutputActivePower": {"unit": "kW", "value": 1.354, "valueDisplay": "1.354"},
+        "PV1ChargingPower": {"unit": "W", "value": 1162, "valueDisplay": "1162"},
+        "PV2ChargingPower": {"unit": "W", "value": 0, "valueDisplay": "0"},
+        "batteryVoltage": {"unit": "V", "value": 28.2, "valueDisplay": "28.2"},
+        "batteryCapacity": {"unit": "%", "value": 100, "valueDisplay": "100"},
+        "batteryChargingCurrent": {"unit": "A", "value": 0, "valueDisplay": "0"},
+        "batteryDischargeCurrent": {"unit": "A", "value": 0, "valueDisplay": "0"},
+        "chargerSourcePriority": {"unit": "A", "value": "3", "valueDisplay": "Only Solar Permitted"},
+        "outputSourcePriority": {"unit": "", "value": "1", "valueDisplay": "Photovoltaic ->mains power ->battery"},
+        "solarFeedToGrid": {"unit": "", "value": "0", "valueDisplay": "disable"},
+        "inputVoltageRange": {"unit": "", "value": "0", "valueDisplay": "Appliance"},
+    },
+    "firingAlarms": [{"key": "lineFail", "name": "Line Fail"}],
+}
+
+
+def test_live_snapshot_populates_every_core_measurement():
+    """The device publishes none of these under the names the history API uses."""
+    merged = api.merge_state_fallbacks({}, LIVE_STATE)
+
+    assert merged["pvInputPower"] == 1162.0        # generationPower, kW → W
+    assert merged["acOutputActivePower"] == 1354.0
+    assert merged["batterySOC"] == 100.0           # batteryCapacity
+    assert merged["batteryVoltage"] == 28.2
+
+
+def test_feed_in_is_zero_when_the_device_cannot_feed_the_grid():
+    """PI30 has no feed-in measurement, only a permit flag; disabled means 0."""
+    merged = api.merge_state_fallbacks({}, LIVE_STATE)
+
+    assert merged["feedInPower"] == 0.0
+    # ac_output - pv + battery + feed_in = 1354 - 1162 + 0 + 0
+    assert merged["gridPower"] == 192.0
+
+
+def test_feed_in_stays_unknown_when_the_flag_says_enabled():
+    state = {"fields": {"solarFeedToGrid": {"value": "1", "valueDisplay": "enable"}}}
+    assert api.merge_state_fallbacks({}, state).get("feedInPower") is None
+
 
 def test_merge_state_fallbacks_fills_feed_in_power_from_alias():
     latest = {"acOutputActivePower": 2000.0, "pvInputPower": 1000.0}
@@ -175,8 +242,98 @@ def test_grid_power_never_goes_negative():
 
 # ── key tables ────────────────────────────────────────────────────────────────
 
-def test_state_and_setting_candidate_tables_cover_the_same_controls():
-    assert set(const.STATE_KEY_CANDIDATES) == set(const.SETTING_KEY_CANDIDATES)
+def test_every_writable_control_can_be_read_back():
+    """Anything we can write must have a state field to read it back from."""
+    assert set(const.SETTING_KEY_CANDIDATES) <= set(const.STATE_KEY_CANDIDATES)
+
+
+def test_boolean_and_number_controls_have_write_keys():
+    for control in (*const.BOOLEAN_CONTROLS, *const.NUMBER_CONTROLS):
+        assert control in const.SETTING_KEY_CANDIDATES, control
+
+
+class _FakeResponse:
+    status_code = 200
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return {"code": 0, "message": "Success"}
+
+
+class _RecordingSession:
+    """Captures what the client would POST, without touching the network."""
+
+    def __init__(self):
+        self.headers = {}
+        self.calls = []
+
+    def post(self, url, json=None, timeout=None):
+        self.calls.append((url, json))
+        return _FakeResponse()
+
+
+def _client_with_recording_session():
+    client = api.SolarOfThingsAPI.__new__(api.SolarOfThingsAPI)
+    client.session = _RecordingSession()
+    client._ensure_token_valid = lambda: None
+    return client
+
+
+def test_write_payload_uses_id_not_device_id():
+    """The endpoint reports success for a deviceId body but changes nothing."""
+    client = _client_with_recording_session()
+
+    client.set_operating_mode("dev-1", const.OUTPUT_PRIORITY_BY_VALUE[2])
+
+    url, body = client.session.calls[0]
+    assert "deviceId=dev-1" in url
+    assert body == {
+        "id": "dev-1",
+        "key": "settingDeviceOutputSourcePriority",
+        "value": "2",
+    }
+
+
+def test_charger_priority_write_sends_the_pcp_code_as_a_string():
+    client = _client_with_recording_session()
+
+    client.set_battery_priority("dev-1", const.CHARGER_PRIORITY_BY_VALUE[3])
+
+    assert client.session.calls[0][1] == {
+        "id": "dev-1",
+        "key": "settingDeviceChargerPriority",
+        "value": "3",
+    }
+
+
+def test_number_control_writes_a_bare_number():
+    client = _client_with_recording_session()
+
+    client.set_number_control("dev-1", "equalizationVoltage", 29.2)
+    client.set_number_control("dev-1", "equalizationPeriod", 30.0)
+
+    assert client.session.calls[0][1]["value"] == 29.2
+    assert client.session.calls[1][1]["value"] == 30
+
+
+def test_boolean_control_writes_quoted_flags():
+    client = _client_with_recording_session()
+
+    client.set_grid_feed_in("dev-1", True)
+
+    assert client.session.calls[0][1] == {
+        "id": "dev-1",
+        "key": "setGridConnectionStatus",
+        "value": "1",
+    }
+
+
+def test_priority_write_keys_are_the_setting_names():
+    """Writes use settingDevice… keys, not the state-snapshot names."""
+    assert const.SETTING_KEY_CANDIDATES["outputSourcePriority"][0] == "settingDeviceOutputSourcePriority"
+    assert const.SETTING_KEY_CANDIDATES["chargerSourcePriority"][0] == "settingDeviceChargerPriority"
 
 
 def test_api_write_maps_match_the_select_options():

--- a/tools/dump_solar_api.py
+++ b/tools/dump_solar_api.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Dump the raw Solar of Things API payloads for one station.
+
+Run this when an entity reads ``unknown``: it prints (and saves) every attribute
+name your inverter actually publishes, so a measurement that the integration
+looks for under the wrong name can be identified and mapped.
+
+    pip install requests pycryptodome
+    python3 tools/dump_solar_api.py --user-id YOURID --station-id 12345
+
+The password is prompted for and never written to the dump.  Tokens are stripped
+from the output, so the resulting JSON is safe to attach to a GitHub issue —
+give it a skim first anyway, since it contains your device names and readings.
+"""
+from __future__ import annotations
+
+import argparse
+import getpass
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+COMPONENT_DIR = REPO_ROOT / "custom_components" / "solar_of_things"
+
+
+def _load_component_modules() -> tuple[Any, Any, Any]:
+    """Import api/const/helpers without pulling in Home Assistant.
+
+    ``custom_components/solar_of_things/__init__.py`` imports Home Assistant, so
+    the package is registered under a private name with only its ``__path__``
+    set.  The submodules then resolve their relative imports normally while the
+    real package ``__init__`` is never executed.
+    """
+    if not COMPONENT_DIR.is_dir():
+        sys.exit(f"Cannot find {COMPONENT_DIR} — run this from the repository.")
+
+    package = types.ModuleType("_sot")
+    package.__path__ = [str(COMPONENT_DIR)]
+    sys.modules["_sot"] = package
+
+    return (
+        importlib.import_module("_sot.api"),
+        importlib.import_module("_sot.const"),
+        importlib.import_module("_sot.helpers"),
+    )
+
+
+def _summarise(label: str, payload: dict[str, Any]) -> None:
+    keys = sorted(payload)
+    print(f"    {label}: {len(keys)} keys")
+    for key in keys:
+        print(f"      • {key}")
+
+
+def _lookup_report(helpers, const, fields: dict, settings: dict) -> None:
+    """Print how the integration resolves the commonly-broken values."""
+    print("\n  Resolution of the values that commonly read 'unknown':")
+
+    for control, by_value, aliases in (
+        ("outputSourcePriority", const.OUTPUT_PRIORITY_BY_VALUE, const.OUTPUT_PRIORITY_ALIASES),
+        ("chargerSourcePriority", const.CHARGER_PRIORITY_BY_VALUE, const.CHARGER_PRIORITY_ALIASES),
+    ):
+        for source, haystack, candidates in (
+            ("state", fields, const.STATE_KEY_CANDIDATES[control]),
+            ("settings", settings, const.SETTING_KEY_CANDIDATES[control]),
+        ):
+            key, entry = helpers.find_entry(haystack, candidates)
+            raw = helpers.entry_value(entry)
+            display = helpers.entry_display(entry)
+            option = helpers.resolve_option(raw, display, by_value, aliases) if key else None
+            print(
+                f"    {control} [{source}]: key={key!r} value={raw!r} "
+                f"display={display!r} → {option!r}"
+            )
+
+    for key, (candidates, kind) in const.TELEMETRY_STATE_FALLBACKS.items():
+        matched, _entry = helpers.find_entry(fields, candidates)
+        value = helpers.state_number(fields, candidates, kind)
+        print(f"    {key} [state]: key={matched!r} → {value!r}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--user-id", required=True, help="Siseli portal account / user-ID")
+    parser.add_argument("--station-id", required=True, help="Station ID from the portal URL")
+    parser.add_argument("--device-id", help="Limit the dump to a single device ID")
+    parser.add_argument("--time-zone", default="Asia/Manila", help="IOT-Time-Zone header value")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("solar_of_things_dump.json"),
+        help="Where to write the JSON dump (default: ./solar_of_things_dump.json)",
+    )
+    args = parser.parse_args()
+
+    api_mod, const, helpers = _load_component_modules()
+
+    password = getpass.getpass("Siseli password: ")
+
+    client = api_mod.SolarOfThingsAPI(
+        user_id=args.user_id,
+        password=password,
+        time_zone=args.time_zone,
+    )
+    print("Logging in …")
+    client.login()
+    print("  ok")
+
+    devices = client.list_devices(args.station_id)
+    if args.device_id:
+        devices = [d for d in devices if str(d.get("id")) == args.device_id]
+    print(f"Found {len(devices)} device(s)")
+
+    dump: dict[str, Any] = {"station_id": args.station_id, "devices": []}
+
+    for device in devices:
+        device_id = str(device.get("id") or "")
+        if not device_id:
+            continue
+        name = device.get("name") or device_id
+        print(f"\n▸ {name} ({device_id})")
+
+        time_series = client.fetch_latest_data(device_id)
+
+        try:
+            settings = client.get_device_settings(device_id)
+        except Exception as err:  # noqa: BLE001 — a dump should survive any failure
+            print(f"    settings fetch failed: {err}")
+            settings = {}
+
+        try:
+            state = client.fetch_state(device_id)
+        except Exception as err:  # noqa: BLE001
+            print(f"    state fetch failed: {err}")
+            state = {}
+
+        fields = helpers.state_fields(state)
+
+        _summarise("time-series", time_series)
+        _summarise("settings cache", settings)
+        _summarise("state snapshot", fields)
+        _lookup_report(helpers, const, fields, settings)
+
+        dump["devices"].append(
+            {
+                "device_id": device_id,
+                "device_meta": device,
+                "time_series": time_series,
+                "settings": settings,
+                "state_fields": fields,
+                "firing_alarms": state.get("firingAlarms"),
+            }
+        )
+
+    args.output.write_text(json.dumps(dump, indent=2, default=str), encoding="utf-8")
+    print(f"\nWrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
# HACS Default Repository Submission (Template)

> Use this template when opening a PR to **HACS default** (https://github.com/hacs/default).  
> If you are opening a PR in *this* repo, adjust wording accordingly.

## Summary
- **Integration name:** Solar of Things
- **Repository:** https://github.com/conexocasa/solar-of-things-ha
- **Category:** Integration
- **Domain:** `solar_of_things`
- **Maintainer:** @conexocasa

## What this PR adds/changes
- Adds the **Solar of Things (Siseli)** Home Assistant custom integration to the HACS default repository.

## Validation checklist
- [ ] The repository contains `custom_components/solar_of_things/manifest.json`
- [ ] `manifest.json` has a valid `version`
- [ ] `hacs.json` exists in the repository root
- [ ] Installation works via HACS (custom repository install test)
- [ ] The integration can connect using `IOT-Token` from https://solar.siseli.com [Source](https://solar.siseli.com)
- [ ] Auto-discovers devices by Station ID (calls `/apis/device/list`)

## User-facing documentation
- README: https://github.com/conexocasa/solar-of-things-ha#readme
- Troubleshooting: https://github.com/conexocasa/solar-of-things-ha/blob/main/TROUBLESHOOTING.md

## Notes
- API behavior is based on the Siseli portal and the reference client: https://github.com/Hyllesen/solar-of-things-solar-usage [Source](https://github.com/Hyllesen/solar-of-things-solar-usage)

