### PR TITLE
Add code for keys generationPower, pvInputVoltage1, pv1InputCurrentFo…

### DIFF
--- a/custom_components/solar_of_things/api.py
+++ b/custom_components/solar_of_things/api.py
@@ -595,13 +595,15 @@ class SolarOfThingsAPI:
         start_time = end_time - timedelta(hours=1)
 
         keys = [
-            "pvInputPower",
+            "generationPower",
+            "pvInputVoltage1",
+            "pv1InputCurrentForBattery",
             "acOutputActivePower",
             "batteryDischargeCurrent",
             "batteryChargingCurrent",
             "batteryVoltage",
             "feedInPower",
-            "batterySOC",
+            "batteryCapacity",
         ]
 
         data = self._post(
@@ -636,6 +638,15 @@ class SolarOfThingsAPI:
             try:
                 latest_values["acOutputActivePower"] = (
                     float(latest_values["acOutputActivePower"]) * 1000.0
+                )
+            except Exception:
+                pass
+                
+        # Unit normalisation: generationPower is kW in API → W
+        if "generationPower" in latest_values:
+            try:
+                latest_values["generationPower"] = (
+                    float(latest_values["generationPower"]) * 1000.0
                 )
             except Exception:
                 pass

--- a/custom_components/solar_of_things/const.py
+++ b/custom_components/solar_of_things/const.py
@@ -52,22 +52,36 @@ TOKEN_REFRESH_LEAD_SECONDS = 300  # 5 minutes
 
 # ─── Sensor keys ───────────────────────────────────────────────────────────────
 SENSOR_KEYS = [
-    "pvInputPower",
+    "generationPower",
+    "pvInputVoltage1",
+    "pv1InputCurrentForBattery",
     "acOutputActivePower",
     "batteryDischargeCurrent",
     "batteryChargingCurrent",
     "batteryVoltage",
     "feedInPower",
     "batteryPower",
-    "batterySOC",
+    "batteryCapacity",
     "gridPower",
     "loadPower",
 ]
 
 SENSOR_DEFINITIONS = {
-    "pvInputPower": {
+    "generationPower": {
         "name": "PV Input Power",
         "unit": "W",
+        "device_class": "power",
+        "icon": "mdi:solar-power",
+    },
+    "pvInputVoltage1": {
+        "name": "PV Input Voltage",
+        "unit": "V",
+        "device_class": "power",
+        "icon": "mdi:solar-power",
+    },
+    "pv1InputCurrentForBattery": {
+        "name": "PV Input Current",
+        "unit": "A",
         "device_class": "power",
         "icon": "mdi:solar-power",
     },
@@ -101,7 +115,7 @@ SENSOR_DEFINITIONS = {
         "device_class": "power",
         "icon": "mdi:battery-charging",
     },
-    "batterySOC": {
+    "batteryCapacity": {
         "name": "Battery State of Charge",
         "unit": "%",
         "device_class": "battery",

--- a/custom_components/solar_of_things/sensor.py
+++ b/custom_components/solar_of_things/sensor.py
@@ -22,13 +22,15 @@ _LOGGER = logging.getLogger(__name__)
 
 # Map sensor key → translation_key (snake_case)
 _TRANSLATION_KEYS: dict[str, str] = {
-    "pvInputPower": "pv_input_power",
+    "generationPower": "pv_charging_power",
+    "pvInputVoltage1": "pv_charging_voltage",
+    "pv1InputCurrentForBattery": "pv_input_current",
     "acOutputActivePower": "ac_output_active_power",
     "batteryDischargeCurrent": "battery_discharge_current",
     "batteryChargingCurrent": "battery_charging_current",
     "batteryVoltage": "battery_voltage",
     "batteryPower": "battery_power",
-    "batterySOC": "battery_soc",
+    "batteryCapacity": "battery_capacity",
     "feedInPower": "feed_in_power",
     "gridPower": "grid_power",
     "loadPower": "load_power",


### PR DESCRIPTION
…rBattery and batteryCapacity

# HACS Default Repository Submission (Template)

> Use this template when opening a PR to **HACS default** (https://github.com/hacs/default).  
> If you are opening a PR in *this* repo, adjust wording accordingly.

## Summary
- **Integration name:** Solar of Things
- **Repository:** https://github.com/conexocasa/solar-of-things-ha
- **Category:** Integration
- **Domain:** `solar_of_things`
- **Maintainer:** @conexocasa

## What this PR adds/changes
- Adds the **Solar of Things (Siseli)** Home Assistant custom integration to the HACS default repository.

## Validation checklist
- [ ] The repository contains `custom_components/solar_of_things/manifest.json`
- [ ] `manifest.json` has a valid `version`
- [ ] `hacs.json` exists in the repository root
- [ ] Installation works via HACS (custom repository install test)
- [ ] The integration can connect using `IOT-Token` from https://solar.siseli.com [Source](https://solar.siseli.com)
- [ ] Auto-discovers devices by Station ID (calls `/apis/device/list`)

## User-facing documentation
- README: https://github.com/conexocasa/solar-of-things-ha#readme
- Troubleshooting: https://github.com/conexocasa/solar-of-things-ha/blob/main/TROUBLESHOOTING.md

## Notes
- API behavior is based on the Siseli portal and the reference client: https://github.com/Hyllesen/solar-of-things-solar-usage [Source](https://github.com/Hyllesen/solar-of-things-solar-usage)

